### PR TITLE
Make ipgen buildable on Linux

### DIFF
--- a/gen/Makefile
+++ b/gen/Makefile
@@ -1,14 +1,25 @@
 .include <bsd.own.mk>
 .include <../Makefile.inc>
 
+OS!=		uname -s
+.if ${OS} != "Linux"
 DESTDIR=	${PREFIX}/bin
+.endif
 
 PROG=		ipgen
-SRCS=		gen.c util.c webserv.c pbuf.c arpresolv.c sequencecheck.c seqtable.c item.c genscript.c flowparse.c pktgen_item.c
+SRCS=		gen.c util.c webserv.c pbuf.c sequencecheck.c seqtable.c item.c genscript.c flowparse.c pktgen_item.c
 CFLAGS+=	-I.. -I/usr/local/include -g -Wall -DIPG_HACK -DHTDOCS=\"${PREFIX}/share/ipgen/htdocs\"
 DPADD=		
 LDADD=		-L../libpkt -lpkt -L../libaddrlist -L/usr/local/lib -laddrlist -lpthread -lc -lcurses -levent -lmd
 MK_MAN=		no
+
+.if ${OS} == "Linux"
+LDADD+=		-lbsd -lcrypto
+CFLAGS+=	-I../../netmap/sys # XXX
+SRCS+=		arpresolv_linux.c
+.else
+SRCS+=		arpresolv.c
+.endif
 
 .include <bsd.prog.mk>
 

--- a/gen/arpresolv_linux.c
+++ b/gen/arpresolv_linux.c
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) 2013 Ryo Shimizu <ryo@nerv.org>
+ * Copyright (c) 2021 Ryota Ozaki <ozaki.ryota@gmail.com>
+ * All rights reserved.
+ *
+ * This file is based on arpresolve.c.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <sys/types.h>
+#include <sys/file.h>
+#include <sys/ioctl.h>
+#include <sys/param.h>
+#include <linux/sysctl.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <netinet/ether.h>
+#include <linux/if.h>
+#include <linux/if_packet.h>
+#include <net/ethernet.h>
+#include <net/if_arp.h>
+#include <netinet/if_ether.h>
+#include <netinet/icmp6.h>
+#include <net/route.h>
+#include <netinet/in.h>
+#include <netinet/ip6.h>
+#include <netinet/icmp6.h>
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <err.h>
+#include <bsd/sys/time.h>
+#include <time.h>
+
+#include "libpkt/libpkt.h"
+#include "arpresolv.h"
+
+
+static int afpkt_read_and_exec(int (*)(void *, unsigned char *, int, const char *), void *, int, const char *, unsigned char *, int);
+
+static void arpquery(int, const char *, struct ether_addr *, struct in_addr *, struct in_addr *);
+static void ndsolicit(int, const char *, struct ether_addr *, struct in6_addr *, struct in6_addr *);
+static int afpkt_open(const char *, int, unsigned int *, int);
+static void afpkt_close(int);
+static int getifinfo(const char *, int *, uint8_t *);
+
+
+struct recvarp_arg {
+	struct in_addr src;
+	struct ether_addr src_eaddr;
+};
+
+struct recvnd_arg {
+	struct in6_addr src;
+	struct ether_addr src_eaddr;
+};
+
+#define BUFSIZE	(1024 * 4)
+static unsigned char buf[BUFSIZE];
+static unsigned int buflen = BUFSIZE;
+
+#ifdef DEBUG
+static int
+usage(void)
+{
+	fprintf(stderr, "usage: arpresolv <interface> <ipv4address>\n");
+	fprintf(stderr, "usage: ndresolv <interface> <ipv6address>\n");
+	return 99;
+}
+
+static int
+getaddr(const char *ifname, const struct in_addr *dstaddr, struct in_addr *srcaddr)
+{
+	int rc;
+	struct ifaddrs *ifa0, *ifa;
+	struct in_addr src, mask;
+	struct in_addr curmask;
+
+	curmask.s_addr = 0;
+	src.s_addr = 0;
+
+	rc = getifaddrs(&ifa0);
+	ifa = ifa0;
+	for (; ifa != NULL; ifa = ifa->ifa_next) {
+		if ((strcmp(ifa->ifa_name, ifname) == 0) &&
+		    (ifa->ifa_addr->sa_family == AF_INET)) {
+
+			if (src.s_addr == 0)
+				src = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+
+			/* lookup addr with netmask */
+			if (dstaddr != NULL) {
+				mask = ((struct sockaddr_in *)ifa->ifa_netmask)->sin_addr;
+				if ((ntohl(mask.s_addr) > ntohl(curmask.s_addr)) &&
+				    ((((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr & mask.s_addr) ==
+				    (dstaddr->s_addr & mask.s_addr))) {
+					src = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+					curmask = mask;
+				}
+			}
+		}
+	}
+
+	if (ifa0 != NULL)
+		freeifaddrs(ifa0);
+
+	*srcaddr = src;
+
+	return (src.s_addr == 0);
+}
+
+static inline int
+ip6_iszero(struct in6_addr *addr)
+{
+	int i;
+	for (i = 0; i < 16; i++) {
+		if (addr->s6_addr[0] != 0)
+			return 0;
+	}
+	return 1;
+}
+
+static int
+getaddr6(const char *ifname, const struct in6_addr *dstaddr, struct in6_addr *srcaddr)
+{
+	int rc;
+	struct ifaddrs *ifa0, *ifa;
+	struct in6_addr src;
+
+	memset(&src, 0, sizeof(src));
+
+	rc = getifaddrs(&ifa0);
+	ifa = ifa0;
+	for (; ifa != NULL; ifa = ifa->ifa_next) {
+		if ((strcmp(ifa->ifa_name, ifname) == 0) &&
+		    (ifa->ifa_addr->sa_family == AF_INET6)) {
+
+			if (ip6_iszero(&src))
+				src = ((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr;
+
+			/* lookup address that has same prefix */
+			if (dstaddr != NULL) {
+				if (memcmp(&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, dstaddr, 8) == 0) {
+					memcpy(&src, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, 16);
+				}
+			}
+		}
+	}
+
+	if (ifa0 != NULL)
+		freeifaddrs(ifa0);
+
+	*srcaddr = src;
+
+	return ip6_iszero(&src);
+}
+
+int
+main(int argc, char *argv[])
+{
+	int rc;
+	char *ifname;
+	struct in_addr src, dst;
+	struct in6_addr src6, dst6;
+	struct ether_addr *eth;
+	char buf[INET6_ADDRSTRLEN];
+
+	if (argc != 3)
+		return usage();
+
+	ifname = argv[1];
+	if (inet_pton(AF_INET, argv[2], &dst) == 1) {
+		rc = getaddr(ifname, &dst, &src);
+		if (rc != 0) {
+			fprintf(stderr, "%s: %s: source address is unknown\n",
+			    ifname, inet_ntoa(dst));
+			return 3;
+		}
+		eth = arpresolv(ifname, &src, &dst);
+	} else if (inet_pton(AF_INET6, argv[2], &dst6) == 1) {
+		rc = getaddr6(ifname, &dst6, &src6);
+		if (rc != 0) {
+			fprintf(stderr, "%s: %s: source address is unknown\n",
+			    ifname, inet_ntop(AF_INET6, &dst6, buf, sizeof(buf)));
+			return 3;
+		}
+		eth = ndpresolv(ifname, &src6, &dst6);
+	} else {
+		printf("%s: invalid host\n", argv[2]);
+		return 2;
+	}
+
+	if (eth != NULL) {
+		printf("%s\n", ether_ntoa(eth));
+		return 0;
+	}
+	return 1;
+}
+#endif
+
+static int
+recv_arpreply(void *arg, unsigned char *buf, int buflen, const char *ifname)
+{
+	struct ether_arp *arp;
+	struct recvarp_arg *recvarparg;
+
+#ifdef DEBUG
+	fprintf(stderr, "recv_arpreply: %s\n", ifname);
+	dumpstr((const char *)buf, buflen, 0);
+#endif
+
+	recvarparg = (struct recvarp_arg *)arg;
+	arp = (struct ether_arp *)buf;
+
+	if (memcmp(arp->arp_spa, &recvarparg->src, sizeof(arp->arp_spa)) != 0)
+		return 0;
+
+	memcpy(&recvarparg->src_eaddr, (struct ether_addr *)(arp->arp_sha), sizeof(struct ether_addr));
+
+	return 1;
+}
+
+static int
+recv_nd(void *arg, unsigned char *buf, int buflen, const char *ifname)
+{
+	struct recvnd_arg *recvndarg;
+	struct icmp6_hdr *icmp6;
+	struct nd_neighbor_advert *na;
+	struct ether_addr *eaddr;
+	struct ip6_hdr *ip6;
+
+#ifdef DEBUG
+	fprintf(stderr, "recv_nd: %s\n", ifname);
+	dumpstr((const char *)buf, buflen, 0);
+#endif
+
+	recvndarg = (struct recvnd_arg *)arg;
+
+	ip6 = (struct ip6_hdr *)buf;
+	if (ip6->ip6_nxt != IPPROTO_ICMPV6)
+		return 0;
+
+	icmp6 = (struct icmp6_hdr *)(buf + sizeof(struct ip6_hdr));
+	if (icmp6->icmp6_type != ND_NEIGHBOR_ADVERT)
+		return 0;
+
+	na = (struct nd_neighbor_advert *)icmp6;
+	eaddr = (struct ether_addr *)((char *)na + sizeof(*na) + 2);
+	memcpy(&recvndarg->src_eaddr, eaddr, sizeof(struct ether_addr));
+
+	return 1;
+}
+
+struct ether_addr *
+arpresolv(const char *ifname, struct in_addr *src, struct in_addr *dst)
+{
+	fd_set rfd;
+	struct timespec end, lim, now;
+	struct timeval tlim;
+	struct ether_addr macaddr;
+	struct ether_addr *found;
+	int fd, rc, mtu, nretry;
+
+	found = NULL;
+
+	fd = afpkt_open(ifname, 0, &buflen, ETH_P_ARP);
+	if (fd < 0) {
+		warn("open: %s", ifname);
+		return NULL;
+	}
+
+	rc = getifinfo(ifname, &mtu, macaddr.ether_addr_octet);
+	if (rc != 0) {
+		warn("%s", ifname);
+		goto close_exit;
+	}
+
+	for (nretry = 3; nretry > 0; nretry--) {
+		arpquery(fd, ifname, &macaddr, src, dst);
+
+		lim.tv_sec = 1;
+		lim.tv_nsec = 0;
+		clock_gettime(CLOCK_MONOTONIC, &end);
+
+		timespecadd(&lim, &end, &end);
+
+		for (;;) {
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			timespecsub(&end, &now, &lim);
+			if (lim.tv_sec < 0)
+				break;
+
+			TIMESPEC_TO_TIMEVAL(&tlim, &lim);
+
+			FD_ZERO(&rfd);
+			FD_SET(fd, &rfd);
+			rc = select(fd + 1, &rfd, NULL, NULL, &tlim);
+			if (rc < 0) {
+				err(1, "select");
+				break;
+			}
+
+			if (rc == 0) {
+				char buf[INET_ADDRSTRLEN];
+				inet_ntop(AF_INET, dst, buf, sizeof(buf));
+				fprintf(stderr, "%s: %s: arp timeout\n", ifname, buf);
+				break;
+			}
+			if (FD_ISSET(fd, &rfd)) {
+				static struct recvarp_arg arg;
+				memset(&arg, 0, sizeof(arg));
+				arg.src = *dst;
+
+				rc = afpkt_read_and_exec(recv_arpreply, (void *)&arg, fd, ifname, buf, buflen);
+				if (rc != 0) {
+					found = &arg.src_eaddr;
+					break;
+				}
+			}
+		}
+		if (found != NULL)
+			break;
+	}
+
+close_exit:
+	afpkt_close(fd);
+
+	return found;
+}
+
+struct ether_addr *
+ndpresolv(const char *ifname, struct in6_addr *src, struct in6_addr *dst)
+{
+	fd_set rfd;
+	struct timespec end, lim, now;
+	struct timeval tlim;
+	struct ether_addr macaddr;
+	struct ether_addr *found;
+	int fd, rc, mtu, nretry;
+
+	found = NULL;
+
+	fd = afpkt_open(ifname, 0, &buflen, ETH_P_IPV6);
+	if (fd < 0) {
+		warn("open: %s", ifname);
+		return NULL;
+	}
+
+	rc = getifinfo(ifname, &mtu, macaddr.ether_addr_octet);
+	if (rc != 0) {
+		warn("%s", ifname);
+		goto close_exit;
+	}
+
+	for (nretry = 3; nretry > 0; nretry--) {
+		ndsolicit(fd, ifname, &macaddr, src, dst);
+
+		lim.tv_sec = 1;
+		lim.tv_nsec = 0;
+		clock_gettime(CLOCK_MONOTONIC, &end);
+
+		timespecadd(&lim, &end, &end);
+
+		for (;;) {
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			timespecsub(&end, &now, &lim);
+			if (lim.tv_sec < 0)
+				break;
+
+			TIMESPEC_TO_TIMEVAL(&tlim, &lim);
+
+			FD_ZERO(&rfd);
+			FD_SET(fd, &rfd);
+			rc = select(fd + 1, &rfd, NULL, NULL, &tlim);
+			if (rc < 0) {
+				err(1, "select");
+				break;
+			}
+
+			if (rc == 0) {
+				char buf[INET6_ADDRSTRLEN];
+				inet_ntop(AF_INET6, dst, buf, sizeof(buf));
+				fprintf(stderr, "%s: [%s]: neighbor solicit timeout\n", ifname, buf);
+				break;
+			}
+			if (FD_ISSET(fd, &rfd)) {
+				static struct recvnd_arg arg;
+				memset(&arg, 0, sizeof(arg));
+				arg.src = *dst;
+
+				rc = afpkt_read_and_exec(recv_nd, (void *)&arg, fd, ifname, buf, buflen);
+				if (rc != 0) {
+					found = &arg.src_eaddr;
+					break;
+				}
+			}
+		}
+		if (found != NULL)
+			break;
+	}
+
+close_exit:
+	afpkt_close(fd);
+
+	return found;
+}
+
+static int
+afpkt_open(const char *ifname, int promisc, unsigned int *buflen, int proto)
+{
+	int fd, rc;
+	struct sockaddr_ll sall;
+
+	fd = socket(AF_PACKET, SOCK_DGRAM, htons(proto));
+	if (fd < 0)
+		return fd;
+
+	memset(&sall, 0, sizeof(sall));
+	sall.sll_family = AF_PACKET;
+	sall.sll_protocol = htons(proto);
+	sall.sll_ifindex = if_nametoindex(ifname);
+
+	rc = bind(fd, (struct sockaddr*)&sall, sizeof(sall));
+	if (rc < 0) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+static void
+afpkt_close(int fd)
+{
+	close(fd);
+}
+
+static int
+getifinfo(const char *ifname, int *mtu, uint8_t *hwaddr)
+{
+	int rc;
+	struct ifreq s;
+	int fd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
+
+	strcpy(s.ifr_name, ifname);
+	rc = ioctl(fd, SIOCGIFHWADDR, &s);
+	close(fd);
+	if (rc < 0)
+		return -1;
+	memcpy(hwaddr, s.ifr_addr.sa_data, ETH_ALEN);
+	return 0;
+}
+
+static void
+arpquery(int fd, const char *ifname, struct ether_addr *sha, struct in_addr *src, struct in_addr *dst)
+{
+	struct sockaddr_ll sall;
+	struct ether_arp arp;
+	int rc;
+
+	memset(&sall, 0, sizeof(sall));
+	sall.sll_family = AF_PACKET;
+	sall.sll_protocol = htons(ETH_P_ARP);
+	sall.sll_ifindex = if_nametoindex(ifname);
+	sall.sll_halen = ETHER_ADDR_LEN;
+	memset(&sall.sll_addr, 0xff, ETHER_ADDR_LEN);
+
+	memset(&arp, 0, sizeof(arp));
+	arp.arp_hrd = htons(ARPHRD_ETHER);
+	arp.arp_pro = htons(ETHERTYPE_IP);
+	arp.arp_hln = ETHER_ADDR_LEN;
+	arp.arp_pln = sizeof(struct in_addr);
+	arp.arp_op  = htons(ARPOP_REQUEST);
+	memcpy(arp.arp_sha, sha, ETHER_ADDR_LEN);
+	memcpy(arp.arp_spa, src, sizeof(*src));
+	memcpy(arp.arp_tpa, dst, sizeof(*dst));
+
+	rc = sendto(fd, (char *)&arp, sizeof(arp), 0, (struct sockaddr *)&sall, sizeof(sall));
+	if (rc < 0)
+		warn("sendto");
+}
+
+static void
+ndsolicit(int fd, const char *ifname, struct ether_addr *sha, struct in6_addr *src, struct in6_addr *dst)
+{
+	struct sockaddr_ll sall;
+	char pktbuf[LIBPKT_PKTBUFSIZE];
+	char *pkt;
+	unsigned int pktlen;
+	int rc;
+
+	memset(&sall, 0, sizeof(sall));
+	sall.sll_family = AF_PACKET;
+	sall.sll_protocol = htons(ETH_P_IPV6);
+	sall.sll_ifindex = if_nametoindex(ifname);
+	sall.sll_halen = ETHER_ADDR_LEN;
+	memset(&sall.sll_addr, 0xff, ETHER_ADDR_LEN);
+
+	pktlen = ip6pkt_neighbor_solicit(pktbuf, sha, src, dst);
+	pkt = pktbuf + sizeof(struct ether_header);
+	pktlen -= sizeof(struct ether_header);
+
+#ifdef DEBUG
+	fprintf(stderr, "send nd-solicit on %s\n", ifname);
+	dumpstr((const char *)pktbuf, pktlen, 0);
+#endif
+
+	rc = sendto(fd, pkt, pktlen, 0, (struct sockaddr *)&sall, sizeof(sall));
+	if (rc < 0)
+		warn("sendto");
+}
+
+static int
+afpkt_read_and_exec(int (*recvcallback)(void *, unsigned char *, int, const char *),
+    void *callbackarg, int fd, const char *ifname,
+    unsigned char *buf, int buflen)
+{
+	ssize_t rc, len;
+
+	rc = recvfrom(fd, buf, buflen, 0, NULL, NULL);
+	if (rc == 0) {
+		fprintf(stderr, "read: bpf: no data\n");
+		return -1;
+	} else if (rc < 0) {
+		warn("read");
+		return -1;
+	} else {
+		len = rc;
+		rc = recvcallback(callbackarg, buf, len, ifname);
+	}
+
+	return rc;
+}

--- a/gen/compat.h
+++ b/gen/compat.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Ryota Ozaki <ozaki.ryota@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#ifndef _COMPAT_H_
+#define _COMPAT_H_
+
+#include <stdbool.h>
+
+#ifdef __linux__
+#define octet		ether_addr_octet
+#endif
+
+#ifndef IF_Mbps
+#define IF_Mbps(n)	((n) * 1000 * 1000)
+#endif
+
+#ifndef IFNAMSIZ
+#define IFNAMSIZ
+#endif
+
+#ifndef ETHERTYPE_FLOWCONTROL
+#define ETHERTYPE_FLOWCONTROL	0x8808
+#endif
+
+#ifndef atomic_fetchadd_32
+#define	atomic_fetchadd_32(t, v) __atomic_fetch_add(t, v, __ATOMIC_CONSUME)
+#endif
+
+#ifndef atomic_swap_32
+#define	atomic_swap_32(t, v) __atomic_exchange_n(t, v, __ATOMIC_SEQ_CST)
+#endif
+
+#ifndef atomic_add_64
+#define	atomic_add_64(t, v) __atomic_add_fetch(t, v, __ATOMIC_SEQ_CST)
+#endif
+
+#ifndef atomic_cmpset_32
+static inline uint32_t
+atomic_cmpset_32(volatile uint32_t *p, uint32_t cmpval, uint32_t newval)
+{
+	bool ret = __atomic_compare_exchange_n(p, &cmpval, newval, false, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED);
+	return ret ? 1 : 0;
+}
+#endif
+
+#endif /* _COMPAT_H_ */

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -28,13 +28,13 @@
 #include <pthread_np.h>
 #endif
 #include <stdio.h>
+#include <stdint.h>
 #include <ctype.h>
 #include <getopt.h>
 #include <poll.h>
 #include <err.h>
 #include <string.h>
 #include <signal.h>
-#include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <net/if.h>
@@ -42,9 +42,13 @@
 #define NETMAP_WITH_LIBS
 #include "netmap_user_localdebug.h"
 #include <net/netmap_user.h>
+#ifdef __linux__
+#include <netinet/ether.h>
+#include <linux/if.h>
+#else
 #include <machine/atomic.h>
+#endif
 #include <net/ethernet.h>
-#include <net/if_mib.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/ip_icmp.h>
@@ -53,6 +57,14 @@
 #include <net/if_arp.h>
 #include <arpa/inet.h>
 
+#ifdef __linux__
+#include <event.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <bsd/string.h>
+#endif
+
+#include "compat.h"
 #include "arpresolv.h"
 #include "libpkt/libpkt.h"
 #include "libaddrlist/libaddrlist.h"
@@ -836,47 +848,6 @@ transmit_set(int ifno, int on)
 }
 
 void
-interface_up(const char *ifname)
-{
-	char buf[256];
-	snprintf(buf, sizeof(buf), "ifconfig %s up", ifname);
-	system(buf);
-}
-
-uint64_t
-interface_get_baudrate(const char *ifname)
-{
-	unsigned int ifindex;
-	struct ifmibdata ifmd;
-	int name[6];
-	size_t len;
-	int rv;
-
-	ifindex = if_nametoindex(ifname);
-
-	if (ifindex == 0) {
-		fprintf(stderr, "Failed to get ifindex\n");
-		exit(1);
-	}
-
-	name[0] = CTL_NET;
-	name[1] = PF_LINK;
-	name[2] = NETLINK_GENERIC;
-	name[3] = IFMIB_IFDATA;
-	name[4] = ifindex;
-	name[5] = IFDATA_GENERAL;
-	len = sizeof(ifmd);
-
-	rv = sysctl(name, 6, &ifmd, &len, 0, 0);
-	if (rv < 0) {
-		warn("Failed to get ifdata\n");
-		return 0;
-	}
-
-	return ifmd.ifmd_data.ifi_baudrate;
-}
-
-void
 interface_wait_linkup(const char *ifname)
 {
 	int i;
@@ -956,37 +927,6 @@ interface_setup(int ifno, const char *ifname)
 }
 
 void
-interface_promisc(int ifno, const char *ifname, int enable, int *old)
-{
-	struct ifreq ifr;
-	int flags, rc;
-
-	memset(&ifr, 0, sizeof(ifr));
-	strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
-	rc = ioctl(interface[ifno].nm_desc->fd, SIOCGIFFLAGS, (caddr_t)&ifr);
-	if (rc == -1) {
-		fprintf(stderr, "netmap: ioctl: SIOCGIFFLAGS: %s\n", strerror(errno));
-		return;
-	}
-
-	flags = (ifr.ifr_flags & 0xffff) | (ifr.ifr_flagshigh << 16);
-
-	if (old != NULL)
-		*old = (flags & IFF_PPROMISC);
-
-	if (enable)
-		flags |= IFF_PPROMISC;
-	else
-		flags &= ~IFF_PPROMISC;
-	ifr.ifr_flags = flags & 0xffff;
-	ifr.ifr_flagshigh = flags >> 16;
-
-	rc = ioctl(interface[ifno].nm_desc->fd, SIOCSIFFLAGS, (caddr_t)&ifr);
-	if (rc == -1)
-		fprintf(stderr, "netmap: ioctl: SIOCSIFFLAGS: %s\n", strerror(errno));
-}
-
-void
 interface_open(int ifno)
 {
 	struct nmreq nmreq;
@@ -1025,7 +965,7 @@ interface_open(int ifno)
 
 	/* for IPv6 multicast packet (ndp, etc), or bridge random L2 address mode */
 	if (use_ipv6 || interface[ifno_another].gw_l2random)
-		interface_promisc(ifno, interface[ifno].ifname, true, &interface[ifno].promisc_save);
+		interface_promisc(interface[ifno].ifname, true, &interface[ifno].promisc_save);
 
 	interface[ifno].opened = 1;
 }
@@ -1038,7 +978,7 @@ interface_close(int ifno)
 	ifno_another = ifno ^ 1;
 
 	if (use_ipv6 || interface[ifno_another].gw_l2random)
-		interface_promisc(ifno, interface[ifno].ifname, interface[ifno].promisc_save, NULL);
+		interface_promisc(interface[ifno].ifname, interface[ifno].promisc_save, NULL);
 
 #if 0	/* XXX */
 	/*

--- a/gen/genscript.c
+++ b/gen/genscript.c
@@ -23,6 +23,9 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/gen/seqtable.c
+++ b/gen/seqtable.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdarg.h>
 #include <unistd.h>

--- a/gen/sequencecheck.c
+++ b/gen/sequencecheck.c
@@ -24,7 +24,7 @@
  * SUCH DAMAGE.
  */
 #include <sys/types.h>
-#include <sys/stdint.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/gen/util.c
+++ b/gen/util.c
@@ -25,11 +25,28 @@
  */
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <err.h>
+#include <errno.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <net/if.h>
+#ifdef __FreeBSD__
+#include <net/if_mib.h>
+#include <sys/sysctl.h>
+#include <sys/ioctl.h>
+#endif
+#ifdef __linux__
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <linux/ethtool.h>
+#include <linux/sockios.h>
+#include <bsd/string.h>
+#endif
 #include "util.h"
+#include "compat.h"
 
 char *
 ip6_sprintf(struct in6_addr *addr)
@@ -274,6 +291,24 @@ getifip6addr(const char *ifname, struct in6_addr *addr, struct in6_addr *netmask
 uint8_t *
 getiflinkaddr(const char *ifname, struct ether_addr *addr)
 {
+#ifdef __linux__
+	int fd;
+	struct ifreq ifr;
+
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+
+	ifr.ifr_addr.sa_family = AF_INET;
+	strncpy(ifr.ifr_name, ifname, IFNAMSIZ-1);
+
+	int r = ioctl(fd, SIOCGIFHWADDR, &ifr);
+	if (r == -1) {
+		return NULL;
+	}
+
+	close(fd);
+	memcpy(addr, &ifr.ifr_hwaddr.sa_data, sizeof(*addr));
+	return (uint8_t *)addr;
+#else
 	struct ifaddrs *ifap, *ifa;
 	const struct sockaddr_dl *sdl;
 	int found = 0;
@@ -299,6 +334,7 @@ getiflinkaddr(const char *ifname, struct ether_addr *addr)
 
 	freeifaddrs(ifap);
 	return found ? (uint8_t *)addr : NULL;
+#endif
 }
 
 int
@@ -317,12 +353,14 @@ listentcp(in_addr_t addr, uint16_t port)
 	setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (void *)&on, sizeof(on));
 
 	memset(&sin, 0, sizeof(sin));
+#ifndef __linux__
 	sin.sin_len = sizeof(sin);
+#endif
 	sin.sin_family = AF_INET;
 	sin.sin_port = htons(port);
 	sin.sin_addr.s_addr = addr;
 
-	rc = bind(s, (struct sockaddr *)&sin, sin.sin_len);
+	rc = bind(s, (struct sockaddr *)&sin, sizeof(sin));
 	if (rc < 0) {
 		warn("bind");
 		close(s);
@@ -336,4 +374,137 @@ listentcp(in_addr_t addr, uint16_t port)
 	}
 
 	return s;
+}
+
+void
+interface_up(const char *ifname)
+{
+#ifdef __linux__
+	char buf[256];
+	snprintf(buf, sizeof(buf), "ip link set up dev %s", ifname);
+	int r = system(buf);
+	(void)r; /* FIXME */
+#else
+	char buf[256];
+	snprintf(buf, sizeof(buf), "ifconfig %s up", ifname);
+	int r = system(buf);
+	(void)r; /* FIXME */
+#endif
+}
+
+uint64_t
+interface_get_baudrate(const char *ifname)
+{
+#ifdef __linux__
+	int s, rc;
+	struct ethtool_value ev = {0};
+	struct ethtool_cmd ec = {0};
+	struct ifreq ifr;
+
+	ev.cmd = ETHTOOL_GLINK;
+	ifr.ifr_data = (char *)&ev;
+	strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+
+	s = socket(AF_INET, SOCK_DGRAM, 0);
+	rc = ioctl(s, SIOCETHTOOL, &ifr);
+	if (rc != 0) {
+		close(s);
+		warn("ioctl(ETHTOOL_GLINK) failed\n");
+		return 0;
+	}
+	ec.cmd = ETHTOOL_GSET;
+	ifr.ifr_data = (char *)&ec;
+	rc = ioctl(s, SIOCETHTOOL, &ifr);
+	close(s);
+	if (rc != 0) {
+		warn("ioctl(ETHTOOL_GSET) failed\n");
+		return 0;
+	}
+	uint32_t speed = ethtool_cmd_speed(&ec);
+	if (speed == 0) {
+		warn("linkspeed unknown\n");
+		return 0;
+	}
+	return IF_Mbps((uint64_t)speed);
+#else
+	unsigned int ifindex;
+	struct ifmibdata ifmd;
+	int name[6];
+	size_t len;
+	int rv;
+
+	ifindex = if_nametoindex(ifname);
+
+	if (ifindex == 0) {
+		warn("Failed to get ifindex\n");
+		return 0;
+	}
+
+	name[0] = CTL_NET;
+	name[1] = PF_LINK;
+	name[2] = NETLINK_GENERIC;
+	name[3] = IFMIB_IFDATA;
+	name[4] = ifindex;
+	name[5] = IFDATA_GENERAL;
+	len = sizeof(ifmd);
+
+	rv = sysctl(name, 6, &ifmd, &len, 0, 0);
+	if (rv < 0) {
+		warn("Failed to get ifdata\n");
+		return 0;
+	}
+
+	return ifmd.ifmd_data.ifi_baudrate;
+#endif
+}
+
+void
+interface_promisc(const char *ifname, int enable, int *old)
+{
+	struct ifreq ifr;
+	int flags, rc;
+	int fd;
+
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd == -1) {
+		warn("socket");
+		return;
+	}
+
+	memset(&ifr, 0, sizeof(ifr));
+	strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+	rc = ioctl(fd, SIOCGIFFLAGS, (caddr_t)&ifr);
+	if (rc == -1) {
+		fprintf(stderr, "ioctl: SIOCGIFFLAGS: %s\n", strerror(errno));
+		goto out;
+	}
+
+#ifdef IFF_PPROMISC
+	flags = (ifr.ifr_flags & 0xffff) | (ifr.ifr_flagshigh << 16);
+
+	if (old != NULL)
+		*old = (flags & IFF_PPROMISC);
+
+	if (enable)
+		flags |= IFF_PPROMISC;
+	else
+		flags &= ~IFF_PPROMISC;
+	ifr.ifr_flags = flags & 0xffff;
+	ifr.ifr_flagshigh = flags >> 16;
+#else
+	flags = ifr.ifr_flags;
+	if (old != NULL)
+		*old = (flags & IFF_PROMISC);
+	if (enable)
+		flags |= IFF_PROMISC;
+	else
+		flags &= ~IFF_PROMISC;
+	ifr.ifr_flags = flags;
+#endif
+
+	rc = ioctl(fd, SIOCSIFFLAGS, (caddr_t)&ifr);
+	if (rc == -1)
+		fprintf(stderr, "ioctl: SIOCSIFFLAGS: %s\n", strerror(errno));
+out:
+	close(fd);
 }

--- a/gen/util.h
+++ b/gen/util.h
@@ -41,6 +41,9 @@ struct in_addr *getifipaddr(const char *, struct in_addr *, struct in_addr *);
 struct in6_addr *getifip6addr(const char *, struct in6_addr *, struct in6_addr *);
 uint8_t *getiflinkaddr(const char *, struct ether_addr *);
 int listentcp(in_addr_t, uint16_t);
+void interface_up(const char *);
+uint64_t interface_get_baudrate(const char *);
+void interface_promisc(const char *, int, int *);
 
 
 char *ip4_sprintf(struct in_addr *);

--- a/gen/util.h
+++ b/gen/util.h
@@ -27,8 +27,10 @@
 #define _UTIL_H_
 
 #include <net/if.h>
+#ifndef __linux__
 #include <net/if_dl.h>
 #include <net/if_types.h>
+#endif
 #include <ifaddrs.h>
 #include <net/ethernet.h>
 

--- a/gen/webserv.c
+++ b/gen/webserv.c
@@ -28,6 +28,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/errno.h>
+#ifdef __linux__
+#include <bsd/sys/queue.h>
+#endif
 #include <event.h>
 #include "webserv.h"
 #include "gen.h"

--- a/libaddrlist/addresses.c
+++ b/libaddrlist/addresses.c
@@ -33,7 +33,16 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#ifdef __linux__
+#include <netinet/ether.h>
+#include <openssl/md5.h>
+#define MD5Init		MD5_Init
+#define MD5Update	MD5_Update
+#define MD5Final	MD5_Final
+#define octet		ether_addr_octet
+#else
 #include <md5.h>
+#endif
 
 #include "libaddrlist.h"
 

--- a/libpkt/Makefile
+++ b/libpkt/Makefile
@@ -16,6 +16,7 @@ CFLAGS+=-DUSE_CPU_IN_CKSUM
 SRCS+=	in_cksum.c
 SRCS+=	cpu_in_cksum.S
 
+CFLAGS+=	-Wno-address-of-packed-member
 
 test: libpkt.a
 	cc test.c libpkt.a && ./a.out | tcpdump -vvvv -n -s0 -X -r -

--- a/libpkt/cpu_in_cksum.S
+++ b/libpkt/cpu_in_cksum.S
@@ -29,7 +29,18 @@
  * SUCH DAMAGE.
  */
 
+#ifdef __linux__
+#define CNAME(csym)		csym
+#define _START_ENTRY	.text; .p2align 4,0x90
+#define _ENTRY(x)	_START_ENTRY; \
+			.globl CNAME(x); .type CNAME(x),@function; CNAME(x):; \
+			.cfi_startproc
+#define	ENTRY(x)	_ENTRY(x)
+#define	END(x)		.size x, . - x; .cfi_endproc
+#endif
+#ifdef __FreeBSD__
 #include <machine/asm.h>
+#endif
 #include "assym_dummy_mbuf.h"
 
 ENTRY(cpu_in_cksum)

--- a/libpkt/ip4pkt.c
+++ b/libpkt/ip4pkt.c
@@ -37,6 +37,10 @@
 #include <netinet/tcp.h>
 #include <net/if_arp.h>
 
+#ifndef IPPROTO_IPV4
+#define IPPROTO_IPV4	4
+#endif
+
 int
 ip4pkt_arpparse(char *buf, int *op, struct ether_addr *sha, in_addr_t *spa, in_addr_t *tpa)
 {

--- a/libpkt/ip6pkt.c
+++ b/libpkt/ip6pkt.c
@@ -57,6 +57,18 @@
 #define IPV6_ADDR_INT16_USL		0xc0fe
 #define IPV6_ADDR_INT16_MLL		0x02ff
 #endif
+#ifndef IPV6_VERSION
+#define IPV6_VERSION          0x60
+#endif
+#ifndef IPV6_VERSION_MASK
+#define IPV6_VERSION_MASK     0xf0
+#endif
+#ifndef IPV6_FLOWINFO_MASK
+#define IPV6_FLOWINFO_MASK    0x0fffffff
+#endif
+#ifdef __linux__
+#define s6_addr8  s6_addr
+#endif
 #ifndef s6_addr8
 #define s6_addr8  __u6_addr.__u6_addr8
 #endif

--- a/libpkt/libpkt.h
+++ b/libpkt/libpkt.h
@@ -40,6 +40,9 @@
 #elif defined(__FreeBSD__)
 #include <net/ethernet.h>
 #define ether_addr_octet octet
+#elif defined(__linux__)
+#include <net/ethernet.h>
+#define __packed	__attribute__((__packed__))
 #endif
 #include <stdio.h>
 

--- a/libpkt/utils.c
+++ b/libpkt/utils.c
@@ -25,6 +25,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/uio.h>


### PR DESCRIPTION
Please consider to merge the commits that enable to build `ipgen` on Linux (Ubuntu 21.04).

The changes of this pull request are mainly tweaks of header inclusions and symbol definitions.  However, some functions need to be reimplemented by Linux APIs.  Especially `arpresolv.c` requires big changes so that it is duplicated into another file, `arpresolv_linux.c`.

The branch is buildable on both Ubuntu 21.04 and FreeBSD 13.0.

You can build `ipgen` on Ubuntu 21.04 with the following instructions:

```
apt install bmake libbsd-dev clang libssl-dev libevent-dev
git clone https://github.com/ozaki-r/ipgen.git
git clone https://github.com/luigirizzo/netmap.git
cd ipgen
git checkout -b linux origin/linux
env CC=clang bmake -m /usr/share/bmake/mk-netbsd
```

Note that the final goal is to run `ipgen` with `AF_XDP` and so the changes don't enable to run `ipgen` with `netmap` on Linux, but just enables to build.  Changes for `AF_XDP` will be coming as another pull request.

Thanks.