### PR TITLE
Support AF_XDP on Linux

### DIFF
--- a/README.linux.md
+++ b/README.linux.md
@@ -1,0 +1,34 @@
+
+# ipgen on Linux
+
+`ipgen` was initially implemented with `netmap` on FreeBSD,
+then ported to Linux.
+On Linux ipgen employs `AF_XDP` instead of netmap.
+
+## Supported distributions
+
+ipgen with AF_XDP is developed and tested on Ubuntu 21.04.
+It should work on recent Fedora Linux too with some minor tweaks.
+
+## Build
+
+```
+apt install bmake libbsd-dev clang libssl-dev libevent-dev libbpf-dev
+git clone https://github.com/iij/ipgen.git
+cd ipgen
+env CC=clang bmake -m /usr/share/bmake/mk-netbsd
+```
+
+## Caveat
+
+ipgen with AF_XDP uses only the 1st hardware queue on a netowrk
+adapter, so if the network adapter uses multiple hardware queues
+ipgen with AF_XDP doesn't work correctly.
+
+You can check if your network adapter, say `eth0`, uses
+multiple queues by `ethtool -l eth0`.
+If so you can change the number of using queues to just one by:
+
+```
+ethtool -L eth0 combined 1
+```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ make depend && make && make install
 ```
 - run ipgen
 
+For Linux users
+===============
+
+ipgen works on Linux too.
+See [README.linux](README.linux.md) for details.
 
 Presentation materials
 ======================

--- a/gen/Makefile
+++ b/gen/Makefile
@@ -8,16 +8,17 @@ DESTDIR=	${PREFIX}/bin
 
 PROG=		ipgen
 SRCS=		gen.c util.c webserv.c pbuf.c sequencecheck.c seqtable.c item.c genscript.c flowparse.c pktgen_item.c
-CFLAGS+=	-I.. -I/usr/local/include -g -Wall -DIPG_HACK -DHTDOCS=\"${PREFIX}/share/ipgen/htdocs\"
+CFLAGS+=	-I.. -I/usr/local/include -g -Wall -DHTDOCS=\"${PREFIX}/share/ipgen/htdocs\"
 DPADD=		
 LDADD=		-L../libpkt -lpkt -L../libaddrlist -L/usr/local/lib -laddrlist -lpthread -lc -lcurses -levent -lmd
 MK_MAN=		no
 
 .if ${OS} == "Linux"
-LDADD+=		-lbsd -lcrypto
-CFLAGS+=	-I../../netmap/sys # XXX
-SRCS+=		arpresolv_linux.c
+LDADD+=		-lbsd -lcrypto -lbpf
+CFLAGS+=	-DUSE_AF_XDP
+SRCS+=		arpresolv_linux.c af_xdp.c
 .else
+CFLAGS+=	-DIPG_HACK -DUSE_NETMAP
 SRCS+=		arpresolv.c
 .endif
 

--- a/gen/af_xdp.c
+++ b/gen/af_xdp.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2021 Ryota Ozaki <ozaki.ryota@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/mman.h>
+#include <sys/resource.h>
+#include <linux/if_link.h>
+#include <bpf/bpf.h>
+#include <bpf/xsk.h>
+#include <bsd/sys/param.h>
+
+#include "af_xdp.h"
+
+#define NUM_FRAMES	4096
+#define FRAME_SIZE	XSK_UMEM__DEFAULT_FRAME_SIZE
+#define BATCH_SIZE	64
+#define NUM_DESCS	XSK_RING_PROD__DEFAULT_NUM_DESCS
+
+struct ax_socket {
+	struct xsk_ring_cons	rring; /* Rx ring */
+	struct xsk_ring_prod	tring; /* Tx ring */
+	struct xsk_ring_prod	fring; /* Fill ring */
+	struct xsk_ring_cons	cring; /* Completion ring */
+	struct xsk_socket	*xsk;
+	struct xsk_umem		*umem;
+	void			*umem_area;
+	uint32_t		inflight_tx_pkts;
+	/* current frame index in the umem_area */
+	uint32_t		tx_frame_idx;
+	bool			do_wakeup;
+};
+
+static struct ax_socket *
+ax_setup_socket(const char *ifname, void *umem_area, size_t size)
+{
+	struct xsk_socket_config cfg;
+	struct ax_socket *axs;
+	int rc;
+
+	axs = calloc(1, sizeof(*axs));
+	if (axs == NULL)
+		return NULL;
+
+	rc = xsk_umem__create(&axs->umem, umem_area, size, &axs->fring, &axs->cring, NULL);
+	if (rc != 0) {
+		fprintf(stderr, "xsk_umem__create failed: %d\n", -rc);
+		free(axs);
+		return NULL;
+	}
+	axs->umem_area = umem_area;
+
+	cfg.rx_size = NUM_DESCS;
+	cfg.tx_size = NUM_DESCS;
+	cfg.libbpf_flags = 0;
+	cfg.xdp_flags = XDP_FLAGS_UPDATE_IF_NOEXIST | XDP_FLAGS_DRV_MODE;
+#ifdef USE_ZEROCOPY
+	cfg.bind_flags = XDP_USE_NEED_WAKEUP | XDP_ZEROCOPY;
+	axs->do_wakeup = true;
+#else
+	cfg.bind_flags = 0;
+	axs->do_wakeup = false;
+#endif
+
+	rc = xsk_socket__create(&axs->xsk, ifname, 0 /* XXX */, axs->umem,
+				 &axs->rring, &axs->tring, &cfg);
+	if (rc != 0) {
+		fprintf(stderr, "xsk_socket__create failed: %d\n", -rc);
+		xsk_umem__delete(axs->umem);
+		free(axs);
+		return NULL;
+	}
+	if (cfg.bind_flags == 0)
+		fprintf(stderr, "warning: zerocopy mode is NOT enabled on %s\n", ifname);
+
+	return axs;
+}
+
+static inline void
+ax_complete_tx0(struct ax_socket *axs, int batch_size)
+{
+	unsigned int done;
+	uint32_t idx;
+
+	if (axs->inflight_tx_pkts == 0)
+		return;
+
+	if (axs->do_wakeup) {
+		if (xsk_ring_prod__needs_wakeup(&axs->tring))
+			sendto(xsk_socket__fd(axs->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
+	} else {
+		/* Tx needs wakeup anyway */
+		sendto(xsk_socket__fd(axs->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
+	}
+
+	done = xsk_ring_cons__peek(&axs->cring, batch_size, &idx);
+	if (done > 0) {
+		xsk_ring_cons__release(&axs->cring, done);
+		axs->inflight_tx_pkts -= done;
+	}
+}
+
+static int
+ax_populate_fill_ring(struct ax_socket *axs)
+{
+	int rc, i;
+	uint32_t idx;
+
+	rc = xsk_ring_prod__reserve(&axs->fring, NUM_DESCS, &idx);
+	if (rc != NUM_DESCS) {
+		fprintf(stderr, "xsk_ring_prod__reserve failed: %d\n", rc);
+		return -1;
+	}
+	for (i = 0; i < NUM_DESCS; i++) {
+		/* Use second half for rx */
+		*xsk_ring_prod__fill_addr(&axs->fring, idx++) =
+			NUM_FRAMES * FRAME_SIZE + i * FRAME_SIZE;
+	}
+	xsk_ring_prod__submit(&axs->fring, NUM_DESCS);
+	return 0;
+}
+
+unsigned int
+ax_wait_for_packets(struct ax_desc *ax_desc, struct ax_rx_handle *handle)
+{
+	struct ax_socket *axs = ax_desc->axs;
+	unsigned int npkts;
+	int ret;
+
+	npkts = xsk_ring_cons__peek(&axs->rring, BATCH_SIZE, &handle->rring_idx);
+	if (npkts == 0) {
+		if (axs->do_wakeup && xsk_ring_prod__needs_wakeup(&axs->fring)) {
+			recvfrom(ax_desc->fd, NULL, 0, MSG_DONTWAIT, NULL, NULL);
+		}
+		return 0;
+	}
+	/*
+	 * Used receive buffers will be immediately set to the fill ring,
+	 * so here we need to preserver the same number of entries as
+	 * received packets.
+	 */
+	ret = xsk_ring_prod__reserve(&axs->fring, npkts, &handle->fring_idx);
+	while (ret != npkts) {
+		if (axs->do_wakeup && xsk_ring_prod__needs_wakeup(&axs->fring)) {
+			recvfrom(ax_desc->fd, NULL, 0, MSG_DONTWAIT, NULL, NULL);
+		}
+		ret = xsk_ring_prod__reserve(&axs->fring, npkts, &handle->fring_idx);
+	}
+
+	handle->npkts = npkts;
+	return npkts;
+}
+
+void
+ax_complete_rx(struct ax_desc *ax_desc, unsigned int n)
+{
+	struct ax_socket *axs = ax_desc->axs;
+
+	xsk_ring_prod__submit(&axs->fring, n);
+	xsk_ring_cons__release(&axs->rring, n);
+}
+
+char *
+ax_get_rx_buf(struct ax_desc *ax_desc, uint32_t *lenp, struct ax_rx_handle *handle)
+{
+	struct ax_socket *axs = ax_desc->axs;
+	const struct xdp_desc *desc = xsk_ring_cons__rx_desc(&axs->rring, handle->rring_idx);
+
+	/*
+	 * XXX registering the buffer before accessing received data is racy
+	 * but it's unlikely to be a problem if the number of descriptors is enough large.
+	 */
+	*xsk_ring_prod__fill_addr(&axs->fring, handle->fring_idx) = desc->addr;
+
+	*lenp = desc->len;
+	return (char *)xsk_umem__get_data(axs->umem_area, desc->addr);
+}
+
+uint32_t
+ax_prepare_tx(struct ax_desc *ax_desc, unsigned int *npkts)
+{
+	struct ax_socket *axs = ax_desc->axs;
+	uint32_t idx;
+
+	*npkts = MIN(*npkts, BATCH_SIZE);
+
+	while (xsk_ring_prod__reserve(&axs->tring, *npkts, &idx) < *npkts) {
+		ax_complete_tx0(axs, *npkts);
+	}
+
+	return idx;
+}
+
+void
+ax_complete_tx(struct ax_desc *ax_desc, unsigned int npkts)
+{
+	struct ax_socket *axs = ax_desc->axs;
+
+	xsk_ring_prod__submit(&axs->tring, npkts);
+	axs->inflight_tx_pkts += npkts;
+	axs->tx_frame_idx += npkts;
+	axs->tx_frame_idx %= NUM_FRAMES;
+	ax_complete_tx0(axs, npkts);
+}
+
+char *
+ax_get_tx_buf(struct ax_desc *ax_desc, uint32_t **lenp, uint32_t idx, int i)
+{
+	struct ax_socket *axs = ax_desc->axs;
+	char *buf;
+	struct xdp_desc *tx_desc = xsk_ring_prod__tx_desc(&axs->tring, idx + i);
+
+	tx_desc->addr = (axs->tx_frame_idx + i) * FRAME_SIZE;
+	buf = xsk_umem__get_data(axs->umem_area, tx_desc->addr);
+
+	*lenp = &tx_desc->len;
+	return buf;
+}
+
+struct ax_desc *
+ax_open(const char *ifname)
+{
+	void *umem_area;
+	size_t mem_size;
+	struct ax_socket *axs;
+	struct ax_desc *ax_desc;
+	int rc;
+
+	ax_desc = malloc(sizeof(*ax_desc));
+	if (ax_desc == NULL) {
+		fprintf(stderr, "malloc failed: %s\n", strerror(errno));
+		return NULL;
+	}
+
+	/* Allocate memory areas for tx and rx at once */
+	mem_size = NUM_FRAMES * 2 * FRAME_SIZE;
+	umem_area = mmap(NULL, mem_size, PROT_READ | PROT_WRITE,
+		   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (umem_area == MAP_FAILED) {
+		fprintf(stderr, "mmap failed: %s\n", strerror(errno));
+		return NULL;
+	}
+
+	axs = ax_setup_socket(ifname, umem_area, mem_size);
+	if (axs == NULL) {
+		fprintf(stderr, "ax_setup_socket failed\n");
+		return NULL;
+	}
+
+	rc = ax_populate_fill_ring(axs);
+	if (rc != 0) {
+		fprintf(stderr, "ax_populate_fill_ring failed\n");
+		return NULL;
+	}
+
+	ax_desc->axs = axs;
+	ax_desc->fd = xsk_socket__fd(axs->xsk);
+
+	return ax_desc;
+}
+
+void
+ax_close(struct ax_desc *desc)
+{
+	struct ax_socket *axs = desc->axs;
+
+	xsk_umem__delete(axs->umem);
+	xsk_socket__delete(axs->xsk);
+}

--- a/gen/af_xdp.h
+++ b/gen/af_xdp.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Ryota Ozaki <ozaki.ryota@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#ifndef _AF_XDP_H_
+#define _AF_XDP_H_
+
+struct ax_socket;
+struct ax_desc
+{
+	int			fd;
+	struct ax_socket	*axs;
+};
+
+struct ax_rx_handle
+{
+	uint32_t	rring_idx;	/* Index in the Rx ring */
+	uint32_t	fring_idx;	/* Index in the Fill ring */
+	unsigned int	npkts;
+};
+
+static inline void
+ax_rx_handle_advance(struct ax_rx_handle *handle)
+{
+	handle->rring_idx++;
+	handle->fring_idx++;
+}
+
+static inline int
+ax_get_fd(struct ax_desc *ax_desc)
+{
+	return ax_desc->fd;
+}
+
+struct ax_desc *
+	ax_open(const char *);
+void	ax_close(struct ax_desc *);
+
+unsigned int
+	ax_wait_for_packets(struct ax_desc *, struct ax_rx_handle *);
+char *
+	ax_get_rx_buf(struct ax_desc *, uint32_t *, struct ax_rx_handle *);
+void	ax_complete_rx(struct ax_desc *, unsigned int);
+
+uint32_t
+	ax_prepare_tx(struct ax_desc *, unsigned int *);
+char *
+	ax_get_tx_buf(struct ax_desc *, uint32_t **, uint32_t, int);
+void	ax_complete_tx(struct ax_desc *, unsigned int);
+
+#endif /* _AF_XDP_H_ */

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -23,25 +23,32 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #ifdef __FreeBSD__
 #include <pthread_np.h>
 #endif
 #include <stdio.h>
-#include <stdint.h>
+#include <stdlib.h>
 #include <ctype.h>
+#include <fcntl.h>
 #include <getopt.h>
 #include <poll.h>
 #include <err.h>
 #include <string.h>
 #include <signal.h>
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <net/if.h>
+#ifdef USE_NETMAP
 #include <net/netmap.h>
 #define NETMAP_WITH_LIBS
 #include "netmap_user_localdebug.h"
 #include <net/netmap_user.h>
+#endif
 #ifdef __linux__
 #include <netinet/ether.h>
 #include <linux/if.h>
@@ -79,6 +86,10 @@
 #include "flowparse.h"
 
 #include "pktgen_item.h"
+
+#ifdef USE_AF_XDP
+#include "af_xdp.h"
+#endif
 
 #define	LINKSPEED_1GBPS		1000000000ULL
 #define	LINKSPEED_10GBPS	10000000000ULL
@@ -223,7 +234,11 @@ static uint16_t seq_magic;
 
 struct interface {
 	int opened;
+#ifdef USE_NETMAP
 	struct nm_desc *nm_desc;
+#elif defined(USE_AF_XDP)
+	struct ax_desc *ax_desc;
+#endif
 	char ifname[IFNAMSIZ];
 	char drvname[IFNAMSIZ];
 	unsigned long unit;	/* Unit number of the interface */
@@ -934,10 +949,11 @@ interface_setup(int ifno, const char *ifname)
 void
 interface_open(int ifno)
 {
+	int ifno_another;
+#ifdef USE_NETMAP
 	struct nmreq nmreq;
 	struct netmap_if *nifp;
 	struct netmap_ring *txring, *rxring;
-	int ifno_another;
 
 	memset(&nmreq, 0, sizeof(nmreq));
 	sprintf(interface[ifno].netmapname, "netmap:%s", interface[ifno].ifname);
@@ -965,6 +981,13 @@ interface_open(int ifno)
 		    interface[ifno].nm_desc->memsize / 1024 / 1024);
 	printf("\n");
 
+#elif defined(USE_AF_XDP)
+	interface[ifno].ax_desc = ax_open(interface[ifno].ifname);
+	if (interface[ifno].ax_desc == NULL) {
+		fprintf(stderr, "failed to initialize AF_XDP\n");
+		exit(1);
+	}
+#endif
 
 	ifno_another = ifno ^ 1;
 
@@ -985,6 +1008,7 @@ interface_close(int ifno)
 	if (use_ipv6 || interface[ifno_another].gw_l2random)
 		interface_promisc(interface[ifno].ifname, interface[ifno].promisc_save, NULL);
 
+#ifdef USE_NETMAP
 #if 0	/* XXX */
 	/*
 	 * XXX: freebsd bug? closing netmap file descriptor sometimes cause panic
@@ -1013,6 +1037,9 @@ interface_close(int ifno)
 	nm_close(interface[ifno].nm_desc);
 #endif
 
+#elif defined(USE_AF_XDP)
+	ax_close(interface[ifno].ax_desc);
+#endif
 	reset_ipg(ifno);
 
 	interface[ifno].opened = 0;
@@ -1381,9 +1408,11 @@ receive_packet(int ifno, struct timespec *curtime, char *buf, uint16_t len)
 		}
 	}
 }
+
 void
 interface_receive(int ifno)
 {
+#ifdef USE_NETMAP
 	char *buf;
 	unsigned int cur, n, i;
 	uint16_t len;
@@ -1412,12 +1441,36 @@ interface_receive(int ifno)
 
 		rxring->head = rxring->cur = cur;
 	}
+#elif defined(USE_AF_XDP)
+	unsigned int i, npkts;
+	struct timespec curtime;
+	struct ax_rx_handle handle;
 
+	npkts = ax_wait_for_packets(interface[ifno].ax_desc, &handle);
+	if (npkts == 0)
+		return;
+
+	clock_gettime(CLOCK_MONOTONIC, &curtime);
+
+	for (i = 0; i < npkts; i++) {
+		char *buf;
+		uint32_t len;
+
+		buf = ax_get_rx_buf(interface[ifno].ax_desc, &len, &handle);
+
+		receive_packet(ifno, &curtime, buf, len);
+
+		ax_rx_handle_advance(&handle);
+	}
+
+	ax_complete_rx(interface[ifno].ax_desc, npkts);
+#endif
 }
 
 int
 interface_transmit(int ifno)
 {
+#ifdef USE_NETMAP
 	char *buf;
 	unsigned int cur, nspace, npkt, n;
 #ifdef USE_MULTI_TX_QUEUE
@@ -1463,6 +1516,36 @@ interface_transmit(int ifno)
 		txring->head = txring->cur = cur;
 #ifdef USE_MULTI_TX_QUEUE
 	}
+#endif
+#elif defined(USE_AF_XDP)
+	unsigned int i, npkt;
+	int sentpkttype;
+	uint32_t idx;
+
+	npkt = interface_need_transmit(ifno);
+	npkt = MIN(npkt, opt_npkt_sync);
+
+	idx = ax_prepare_tx(interface[ifno].ax_desc, &npkt);
+
+	clock_gettime(CLOCK_MONOTONIC, &currenttime_tx);
+
+	for (i = 0; i < npkt; i++) {
+		char *buf;
+		uint32_t *lenp;
+
+		buf = ax_get_tx_buf(interface[ifno].ax_desc, &lenp, idx, i);
+
+		sentpkttype = interface_load_transmit_packet(ifno, buf, (uint16_t *)lenp);
+		if (sentpkttype < 0)
+			break;
+		if (opt_bps_include_preamble)
+			interface[ifno].counter.tx_byte += *lenp + DEFAULT_IFG + DEFAULT_PREAMBLE + FCS;
+		else
+			interface[ifno].counter.tx_byte += *lenp + FCS;
+		interface[ifno].counter.tx++;
+	}
+
+	ax_complete_tx(interface[ifno].ax_desc, npkt);
 #endif
 
 	return 0;
@@ -1908,7 +1991,9 @@ tx_thread_main(void *arg)
 		}
 
 		interface_transmit(ifno);
+#ifdef USE_NETMAP
 		ioctl(interface[ifno].nm_desc->fd, NIOCTXSYNC, NULL);
+#endif
 	}
 
 	return NULL;
@@ -1927,7 +2012,11 @@ rx_thread_main(void *arg)
 
 	/* setup poll */
 	memset(pollfd, 0, sizeof(pollfd));
+#ifdef USE_NETMAP
 	pollfd[0].fd = interface[ifno].nm_desc->fd;
+#elif defined(USE_AF_XDP)
+	pollfd[0].fd = ax_get_fd(interface[ifno].ax_desc);
+#endif
 
 	while (do_quit == 0) {
 		pollfd[0].events = POLLIN;
@@ -2823,10 +2912,14 @@ itemlist_callback_startstop(struct itemlist *itemlist, struct item *item, void *
 void
 control_init_items(struct itemlist *itemlist)
 {
+#ifdef USE_NETMAP
 	static int netmap_api = NETMAP_API;
+#endif
 
 	itemlist_register_item(itemlist, ITEMLIST_ID_IPGEN_VERSION, NULL, ipgen_version);
+#ifdef USE_NETMAP
 	itemlist_setvalue(itemlist, ITEMLIST_ID_NETMAP_API, &netmap_api);
+#endif
 
 	itemlist_register_item(itemlist, ITEMLIST_ID_IFNAME0, NULL, interface[0].decorated_ifname);
 	itemlist_register_item(itemlist, ITEMLIST_ID_IFNAME1, NULL, interface[1].decorated_ifname);
@@ -4018,6 +4111,23 @@ printf("opt_bps_include_preamble=%d\n", opt_bps_include_preamble);
 			pthread_set_name_np(rxthread0, buf);
 		}
 #endif
+#ifdef __linux__
+		int error, i;
+		long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
+		cpu_set_t cpuset;
+		CPU_ZERO(&cpuset);
+		/* Assign even CPU cores to Tx threads, the others to Rx thread */
+		for (i = 0; i < nprocs; i += 2)
+			CPU_SET(i, &cpuset);
+		error = pthread_setaffinity_np(txthread0, sizeof(cpuset), &cpuset);
+		error = pthread_setaffinity_np(rxthread0, sizeof(cpuset), &cpuset);
+#if 0
+		struct sched_param param;
+		param.sched_priority = sched_get_priority_max(SCHED_FIFO);
+		error = pthread_setschedparam(txthread0, SCHED_FIFO, &param);
+		error = pthread_setschedparam(rxthread0, SCHED_FIFO, &param);
+#endif
+#endif
 	}
 	if (!opt_rxonly) {
 		pthread_create(&txthread1, NULL, tx_thread_main, &ifnum[1]);
@@ -4030,6 +4140,27 @@ printf("opt_bps_include_preamble=%d\n", opt_bps_include_preamble);
 			snprintf(buf, sizeof(buf), "%s-rx", interface[1].ifname);
 			pthread_set_name_np(rxthread1, buf);
 		}
+#endif
+#ifdef __linux__
+		int error, i;
+		long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
+		cpu_set_t cpuset;
+		CPU_ZERO(&cpuset);
+		if (nprocs == 1) {
+			fprintf(stderr, "warning: Tx and Rx threads share a CPU");
+			CPU_SET(0, &cpuset);
+		} else {
+			for (i = 1; i < nprocs; i += 2)
+				CPU_SET(i, &cpuset);
+		}
+		error = pthread_setaffinity_np(txthread1, sizeof(cpuset), &cpuset);
+		error = pthread_setaffinity_np(rxthread1, sizeof(cpuset), &cpuset);
+#if 0
+		struct sched_param param;
+		param.sched_priority = sched_get_priority_max(SCHED_FIFO);
+		error = pthread_setschedparam(txthread1, SCHED_FIFO, &param);
+		error = pthread_setschedparam(rxthread1, SCHED_FIFO, &param);
+#endif
 #endif
 	}
 

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -4002,7 +4002,7 @@ printf("opt_bps_include_preamble=%d\n", opt_bps_include_preamble);
 	if (!opt_txonly) {
 		pthread_create(&txthread0, NULL, tx_thread_main, &ifnum[0]);
 		pthread_create(&rxthread0, NULL, rx_thread_main, &ifnum[0]);
-#ifdef __FreeBSD__
+#ifdef pthread_set_name_np
 		{
 			char buf[128];
 			snprintf(buf, sizeof(buf), "%s-tx", interface[0].ifname);
@@ -4015,7 +4015,7 @@ printf("opt_bps_include_preamble=%d\n", opt_bps_include_preamble);
 	if (!opt_rxonly) {
 		pthread_create(&txthread1, NULL, tx_thread_main, &ifnum[1]);
 		pthread_create(&rxthread1, NULL, rx_thread_main, &ifnum[1]);
-#ifdef __FreeBSD__
+#ifdef pthread_set_name_np
 		{
 			char buf[128];
 			snprintf(buf, sizeof(buf), "%s-tx", interface[1].ifname);

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -578,11 +578,11 @@ set_pap(int ifno, unsigned int pap)
 static void
 reset_ipg(int ifno)
 {
+#ifdef IPG_HACK
 	char buf[256];
 	const char *drvname = interface[ifno].drvname;
 	unsigned long unit = interface[ifno].unit;
 
-#ifdef IPG_HACK
 	if (!support_ipg)
 		return;
 
@@ -625,7 +625,6 @@ update_transmit_max_sustained_pps(int ifno, int ipg)
 static void
 calc_ipg(int ifno)
 {
-	int new_tipg;
 
 	if (!opt_ipg) {
 		update_transmit_max_sustained_pps(ifno, DEFAULT_IFG);
@@ -633,6 +632,8 @@ calc_ipg(int ifno)
 	}
 
 #ifdef IPG_HACK
+	int new_tipg;
+
 	if (!support_ipg) {
 		update_transmit_max_sustained_pps(ifno, DEFAULT_IFG);
 		return;


### PR DESCRIPTION
This pull request includes changes for supporting `AF_XDP` as a packet processing engine of `ipgen` on Linux.

`AF_XDP` is a facility to enable userspace programs to send/receive packets efficiently.  Please see [the official document](https://www.kernel.org/doc/html/latest/networking/af_xdp.html) for more information.

This implementation doesn't support all features of `ipgen` yet (e.g., IPG tweaks), but it works on basic usages.

It is tested on Ubuntu 21.04 with `veth` and also on Fedora 34 with `igb`.

## How to test

This is a sample usage of `ipgen` on Linux with netns and `veth`.

### Setup

The following script sets up one network namespace with two veth pairs that acts a DUT with two network interfaces.

Run the script as root.

```
ip link add name tx-veth0 type veth peer name tx-veth1
ip netns add af_xdp
ip link set tx-veth1 netns af_xdp
ip link add name rx-veth0 type veth peer name rx-veth1
ip link set rx-veth1 netns af_xdp

ip link set up dev tx-veth0
ip link set up dev rx-veth0
ip a add 10.0.1.2/24 dev tx-veth0
ip a add 10.0.2.2/24 dev rx-veth0

ip netns exec af_xdp ip a add 10.0.1.1/24 dev tx-veth1 
ip netns exec af_xdp ip a add 10.0.2.1/24 dev rx-veth1 
ip netns exec af_xdp ip link set up dev tx-veth1
ip netns exec af_xdp ip link set up dev rx-veth1

ip netns exec af_xdp sysctl -w net.ipv4.conf.all.forwarding=1
ip netns exec af_xdp sysctl -w net.ipv6.conf.all.forwarding=1
```

### Run ipgen

```
sudo ./gen/ipgen -T tx-veth0,10.0.1.1 -R rx-veth0,10.0.2.1 --rfc2544 --rfc2544-slowstart --rfc2544-tolerable-error-rate 0.1 --rfc2544-trial-duration 10
```
