### PR TITLE
Support TIPG and PAP on Linux & some fixes

### DIFF
--- a/gen/GNUmakefile
+++ b/gen/GNUmakefile
@@ -6,7 +6,7 @@ CFLAGS+=	-I.. -I/usr/local/include -g -Wall -DHTDOCS=\"${PREFIX}/share/ipgen/htd
 LDADD=		-L../libpkt -lpkt -L../libaddrlist -L/usr/local/lib -laddrlist -lpthread -lc -lcurses -levent -lmd
 
 ifeq ($(shell uname),Linux)
-LDADD+=		-lbsd -lcrypto -lbpf
+LDADD+=		-lbsd -lcrypto -lxdp
 CFLAGS+=	-DUSE_AF_XDP
 SRCS+=		arpresolv_linux.c af_xdp.c
 else

--- a/gen/GNUmakefile
+++ b/gen/GNUmakefile
@@ -7,7 +7,7 @@ LDADD=		-L../libpkt -lpkt -L../libaddrlist -L/usr/local/lib -laddrlist -lpthread
 
 ifeq ($(shell uname),Linux)
 LDADD+=		-lbsd -lcrypto -lxdp
-CFLAGS+=	-DUSE_AF_XDP
+CFLAGS+=	-DIPG_HACK -DUSE_AF_XDP
 SRCS+=		arpresolv_linux.c af_xdp.c
 else
 CFLAGS+=	-DIPG_HACK -DUSE_NETMAP

--- a/gen/af_xdp.c
+++ b/gen/af_xdp.c
@@ -33,7 +33,7 @@
 #include <sys/resource.h>
 #include <linux/if_link.h>
 #include <bpf/bpf.h>
-#include <bpf/xsk.h>
+#include <xdp/xsk.h>
 #include <bsd/sys/param.h>
 
 #include "af_xdp.h"

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2635,7 +2635,7 @@ static int
 rfc2544_down_pps(void)
 {
 	if ((rfc2544_work[rfc2544_nthtest].curpps - rfc2544_work[rfc2544_nthtest].ppsresolution) <= rfc2544_work[rfc2544_nthtest].minpps) {
-		rfc2544_work[rfc2544_nthtest].curpps = rfc2544_work[rfc2544_nthtest].minpps - rfc2544_work[rfc2544_nthtest].ppsresolution;
+		rfc2544_work[rfc2544_nthtest].curpps = rfc2544_work[rfc2544_nthtest].minpps;
 		return 1;
 	}
 

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -640,6 +640,30 @@ statistics_clear(void)
 	return 0;
 }
 
+#ifdef __linux__
+int
+getdrvname(const char *ifname, char *drvname)
+{
+	ssize_t n;
+	char pathbuf[256];
+	char linkbuf[256];
+	char *drvstr;
+
+	snprintf(pathbuf, sizeof(pathbuf), "/sys/class/net/%s/device/driver", ifname);
+	n = readlink(pathbuf, linkbuf, sizeof(linkbuf));
+	if (n == -1)
+		return -1;
+
+	/* ex /sys/bus/pci/drivers/ixgbe */
+	drvstr = strrchr(linkbuf, '/');
+	if (drvstr == NULL)
+		return -1;
+	drvstr++;
+	strcpy(drvname, drvstr);
+
+	return 0;
+}
+#else
 int
 getifunit(const char *ifname, char *drvname, unsigned long *unit)
 {
@@ -660,12 +684,36 @@ getifunit(const char *ifname, char *drvname, unsigned long *unit)
 
 	return 0;
 }
+#endif
 
 #ifdef IPG_HACK
+
+#ifdef __linux__
+static int
+write_if_sysfs(const char *ifname, const char *target, unsigned int val)
+{
+	char path[64], buf[128];
+
+	snprintf(path, sizeof(path), "/sys/class/net/%s/%s", ifname, target);
+	if (access(path, W_OK) != 0)
+		return -1;
+	snprintf(buf, sizeof(buf), "echo %u > %s", val, path);
+	return system(buf);
+}
+#endif
+
 /* set Transmit Inter Packet Gap */
 static int
 set_ipg(int ifno, unsigned int ipg)
 {
+#ifdef __linux__
+	const char *ifname = interface[ifno].ifname;
+
+	if (ifname == NULL || ifname[0] == '\0')
+		return -1;
+	DEBUGLOG("%s: setting tipg=%u\n", ifname, ipg);
+	return write_if_sysfs(ifname, "tipg", ipg);
+#else
 	char buf[256];
 	const char *drvname = interface[ifno].drvname;
 	unsigned long unit = interface[ifno].unit;
@@ -677,6 +725,7 @@ set_ipg(int ifno, unsigned int ipg)
 
 		return system(buf);
 	}
+#endif
 
 	return -1;
 }
@@ -685,6 +734,14 @@ set_ipg(int ifno, unsigned int ipg)
 static int
 set_pap(int ifno, unsigned int pap)
 {
+#ifdef __linux__
+	const char *ifname = interface[ifno].ifname;
+
+	if (ifname == NULL || ifname[0] == '\0')
+		return -1;
+	DEBUGLOG("%s: setting pap=%u\n", ifname, pap);
+	return write_if_sysfs(ifname, "pap", pap);
+#else
 	char buf[256];
 	const char *drvname = interface[ifno].drvname;
 	unsigned long unit = interface[ifno].unit;
@@ -696,6 +753,7 @@ set_pap(int ifno, unsigned int pap)
 	}
 
 	return -1;
+#endif
 }
 #endif /* IPG_HACK */
 
@@ -712,21 +770,33 @@ reset_ipg(int ifno)
 
 	if ((strncmp(drvname, "em", IFNAMSIZ) == 0)
 	    || (strncmp(drvname, "igb", IFNAMSIZ) == 0)) {
+#ifdef __linux__
+		snprintf(buf, sizeof(buf), "echo 8 > /sys/class/net/%s/tipg", interface[ifno].ifname);
+#else
 		snprintf(buf, sizeof(buf), "sysctl -q -w dev.%s.%lu.tipg=8 > /dev/null", drvname, unit);
+#endif
 
 		system(buf);
 	} else if (strncmp(drvname, "ix", IFNAMSIZ) == 0) {
 		int rv;
 
 		/* Try TIPG first */
+#ifdef __linux__
+		snprintf(buf, sizeof(buf), "echo 0 > /sys/class/net/%s/tipg 2>/dev/null", interface[ifno].ifname);
+#else
 		snprintf(buf, sizeof(buf), "sysctl -q -w dev.%s.%lu.tipg=0 > /dev/null", drvname, unit);
+#endif
 
 		rv = system(buf);
 		if (rv == 0)
 			return;
 
 		/* If failed, try PAP */
+#ifdef __linux__
+		snprintf(buf, sizeof(buf), "echo 0 > /sys/class/net/%s/pap", interface[ifno].ifname);
+#else
 		snprintf(buf, sizeof(buf), "sysctl -q -w dev.%s.%lu.pap=0 > /dev/null", drvname, unit);
+#endif
 
 		system(buf);
 	}
@@ -763,8 +833,8 @@ calc_ipg(int ifno)
 		return;
 	}
 
-	if ((strncmp(interface[ifno].ifname, "em", 2) == 0) ||
-	    (strncmp(interface[ifno].ifname, "igb", 3) == 0)) {
+	if ((strncmp(interface[ifno].drvname, "em", 2) == 0) ||
+	    (strncmp(interface[ifno].drvname, "igb", 3) == 0)) {
 
 		if (interface[ifno].transmit_pps == 0) {
 			dev_tipg = INT_MAX;
@@ -782,7 +852,7 @@ calc_ipg(int ifno)
 
 		ipg = dev_tipg + 4;	/* restore offset */
 		update_transmit_max_sustained_pps(ifno, ipg);
-	} else if (strncmp(interface[ifno].ifname, "ix", 2) == 0) {
+	} else if (strncmp(interface[ifno].drvname, "ix", 2) == 0) {
 		unsigned long bps;
 		uint32_t new_pap;
 		int error;
@@ -3512,6 +3582,25 @@ main(int argc, char *argv[])
 				strncpy(ifname[ifno], p, sizeof(ifname[0]));
 
 #ifdef IPG_HACK
+#ifdef __linux__
+				char path[256];
+
+				snprintf(path, sizeof(path), "/sys/class/net/%s/tipg", ifname[ifno]);
+				if (access(path, R_OK|W_OK) == 0) {
+					support_ipg = 1;
+					printf("%s TIPG feature supported\n", ifname[ifno]);
+				} else {
+					snprintf(path, sizeof(path), "/sys/class/net/%s/pap", ifname[ifno]);
+					if (access(path, R_OK|W_OK) == 0) {
+						support_ipg = 1;
+						printf("%s PAP feature supported\n", ifname[ifno]);
+					} else
+						printf("%s Neither TIPG nor PAP feature supported\n", ifname[ifno]);
+				}
+
+				if (getdrvname(ifname[ifno], drvname[ifno]) == -1)
+					printf("warning: failed to get drvname of %s\n", ifname[ifno]);
+#else
 				if (getifunit(ifname[ifno], drvname[ifno], &unit[ifno]) != -1) {
 					char strbuf[256];
 
@@ -3529,6 +3618,7 @@ main(int argc, char *argv[])
 					}
 				}
 #endif
+#endif /* IPG_HACK */
 				p = strsep(&s, ",");
 				/* parse IPv4 or IPv6 or MAC-ADDRESS */
 				if (inet_pton(AF_INET, p, &interface[ifno].gwaddr) == 1) {

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2797,6 +2797,8 @@ rfc2544_test(int unsigned n)
 			} else {
 				/* pause frame workaround */
 				const uint64_t pause_detect_threshold = 10000; /* XXXX */
+				DEBUGLOG("RFC2544: tx_underrun=%lu, pause_detect_threshold=%lu, tx=%lu, tolerable_error_rate=%.4f\n",
+				    interface[1].counter.tx_underrun, pause_detect_threshold, interface[1].counter.tx, opt_rfc2544_tolerable_error_rate);
 				if (interface[1].counter.tx_underrun > pause_detect_threshold
 				    && (((interface[1].counter.tx_underrun * 100.0) / interface[1].counter.tx)
 					> opt_rfc2544_tolerable_error_rate)) {
@@ -2804,6 +2806,12 @@ rfc2544_test(int unsigned n)
 					DEBUGLOG("RFC2544: pktsize=%d, pps=%d, pause frame workaround. down pps\n",
 					    rfc2544_work[rfc2544_nthtest].pktsize,
 					    rfc2544_work[rfc2544_nthtest].curpps);
+				} else if ((interface[0].counter.rx * 100.0 / interface[1].counter.tx) < opt_rfc2544_tolerable_error_rate) {
+					do_down_pps = 1;
+					DEBUGLOG("RFC2544: pktsize=%d, pps=%d, tx=%llu, rx=%llu, enough packets not received. down pps\n",
+					    rfc2544_work[rfc2544_nthtest].pktsize,
+					    rfc2544_work[rfc2544_nthtest].curpps,
+					    (unsigned long long)interface[1].counter.tx, (unsigned long long)interface[0].counter.rx);
 				} else {
 					/* no drop. OK! */
 					measure_done = rfc2544_up_pps();

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -816,12 +816,13 @@ calc_ipg(int ifno)
 		}
 		/*  / 1000 / 1000; */
 
-		if ((bps % (1 * 1000 * 1000 * 1000)) > 0)
-			bps += 1 * 1000 * 1000 * 1000;
-		new_pap = bps / (1 * 1000 * 1000 * 1000);
+		DEBUGLOG("pps=%u, bps=%lu\n", interface[ifno].transmit_pps, bps);
+		if ((bps % (interface[ifno].maxlinkspeed / 10)) > 0)
+			bps += interface[ifno].maxlinkspeed / 10;
+		new_pap = bps / (interface[ifno].maxlinkspeed / 10);
 
 		if (new_pap == 0)
-			new_pap = 1; /* 1Gbps */
+			new_pap = 1;
 		if (new_pap >= 10)
 			new_pap = 0;
 

--- a/patch/linux-6.2.8-igb-tipg.dif
+++ b/patch/linux-6.2.8-igb-tipg.dif
@@ -1,0 +1,147 @@
+diff --git a/drivers/net/ethernet/intel/igb/e1000_regs.h b/drivers/net/ethernet/intel/igb/e1000_regs.h
+index eb9f6da9208a..8347d4e062f1 100644
+--- a/drivers/net/ethernet/intel/igb/e1000_regs.h
++++ b/drivers/net/ethernet/intel/igb/e1000_regs.h
+@@ -347,6 +347,23 @@
+ #define E1000_VLVF(_n)         (0x05D00 + (4 * (_n))) /* VLAN VM Filter */
+ #define E1000_VMVIR(_n)        (0x03700 + (4 * (_n)))
+ 
++/* Default values for the transmit IPG register */
++#define DEFAULT_82542_TIPG_IPGT        10
++#define DEFAULT_82543_TIPG_IPGT_FIBER  9
++#define DEFAULT_82543_TIPG_IPGT_COPPER 8
++
++#define E1000_TIPG_IPGT_MASK  0x000003FF
++#define E1000_TIPG_IPGR1_MASK 0x000FFC00
++#define E1000_TIPG_IPGR2_MASK 0x3FF00000
++
++#define DEFAULT_82542_TIPG_IPGR1 2
++#define DEFAULT_82543_TIPG_IPGR1 8
++#define E1000_TIPG_IPGR1_SHIFT  10
++
++#define DEFAULT_82542_TIPG_IPGR2 10
++#define DEFAULT_82543_TIPG_IPGR2 6
++#define E1000_TIPG_IPGR2_SHIFT  20
++
+ struct e1000_hw;
+ 
+ u32 igb_rd32(struct e1000_hw *hw, u32 reg);
+diff --git a/drivers/net/ethernet/intel/igb/igb_hwmon.c b/drivers/net/ethernet/intel/igb/igb_hwmon.c
+index 21a29a0ca7f4..1056dd978c2e 100644
+--- a/drivers/net/ethernet/intel/igb/igb_hwmon.c
++++ b/drivers/net/ethernet/intel/igb/igb_hwmon.c
+@@ -142,10 +142,100 @@ static void igb_sysfs_del_adapter(struct igb_adapter *adapter)
+ {
+ }
+ 
++static ssize_t attr_show(struct device *d, char *buf,
++			 ssize_t(*format) (struct net_device *, char *))
++{
++	ssize_t len;
++
++	/* Synchronize with ioctls that may shut down the device */
++	rtnl_lock();
++	len = (*format) (to_net_dev(d), buf);
++	rtnl_unlock();
++	return len;
++}
++
++static ssize_t attr_store(struct device *d,
++			  const char *buf, size_t len,
++			  ssize_t(*set) (struct net_device *, unsigned int),
++			  unsigned int min_val, unsigned int max_val)
++{
++	ssize_t ret;
++	unsigned int val;
++
++	if (!capable(CAP_NET_ADMIN))
++		return -EPERM;
++
++	ret = kstrtouint(buf, 0, &val);
++	if (ret)
++		return ret;
++	if (val < min_val || val > max_val)
++		return -EINVAL;
++
++	rtnl_lock();
++	ret = (*set) (to_net_dev(d), val);
++	if (!ret)
++		ret = len;
++	rtnl_unlock();
++	return ret;
++}
++
++static ssize_t format_tipg(struct net_device *dev, char *buf)
++{
++	struct igb_adapter *adapter = netdev_priv(dev);
++	struct e1000_hw *hw = &adapter->hw;
++	u32 val;
++	val = rd32(E1000_TIPG) & E1000_TIPG_IPGT_MASK;
++	return sprintf(buf, "%u\n", val);
++}
++
++static ssize_t show_tipg(struct device *d, struct device_attribute *attr,
++			   char *buf)
++{
++	return attr_show(d, buf, format_tipg);
++}
++
++static ssize_t set_tipg(struct net_device *dev, unsigned int val)
++{
++	struct igb_adapter *adapter = netdev_priv(dev);
++	struct e1000_hw *hw = &adapter->hw;
++	u32 reg;
++
++	reg = rd32(E1000_TIPG);
++	reg &= ~E1000_TIPG_IPGT_MASK;
++	dev_dbg(&dev->dev, "setting tipg=%u\n", val);
++	reg |= val;
++	wr32(E1000_TIPG, reg);
++
++	return 0;
++}
++
++static ssize_t store_tipg(struct device *d, struct device_attribute *attr,
++			      const char *buf, size_t len)
++{
++	return attr_store(d, buf, len, set_tipg, 0, 16);
++}
++
++#define IGB_ATTR_RW(name, show_method, store_method) \
++static DEVICE_ATTR(name, 0644, show_method, store_method)
++
++IGB_ATTR_RW(tipg, show_tipg, store_tipg);
++
++static struct attribute *igb_attrs[] = {
++	&dev_attr_tipg.attr,
++	NULL
++};
++
++static const struct attribute_group igb_attr_group = {
++	.attrs = igb_attrs,
++};
++
+ /* called from igb_main.c */
+ void igb_sysfs_exit(struct igb_adapter *adapter)
+ {
+ 	igb_sysfs_del_adapter(adapter);
++	/* XXX it's not hwmon */
++	sysfs_remove_group(&adapter->netdev->dev.kobj,
++			   &igb_attr_group);
+ }
+ 
+ /* called from igb_main.c */
+@@ -157,6 +247,13 @@ int igb_sysfs_init(struct igb_adapter *adapter)
+ 	unsigned int i;
+ 	int rc = 0;
+ 
++	/* XXX it's not hwmon */
++	rc = sysfs_create_group(&adapter->netdev->dev.kobj, &igb_attr_group);
++	if (rc) {
++		dev_err(&adapter->netdev->dev, "cannot create sysfs group\n");
++		goto exit;
++	}
++
+ 	/* If this method isn't defined we don't support thermals */
+ 	if (adapter->hw.mac.ops.init_thermal_sensor_thresh == NULL)
+ 		goto exit;

--- a/patch/linux-6.2.8-ixgbe-pap.dif
+++ b/patch/linux-6.2.8-ixgbe-pap.dif
@@ -1,0 +1,135 @@
+diff --git a/drivers/net/ethernet/intel/ixgbe/ixgbe_sysfs.c b/drivers/net/ethernet/intel/ixgbe/ixgbe_sysfs.c
+index 204844288c16..499d6b4c2d58 100644
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_sysfs.c
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_sysfs.c
+@@ -136,10 +136,103 @@ static void ixgbe_sysfs_del_adapter(struct ixgbe_adapter *adapter)
+ {
+ }
+ 
++static ssize_t attr_show(struct device *d, char *buf,
++			 ssize_t(*format) (struct net_device *, char *))
++{
++	ssize_t len;
++
++	/* Synchronize with ioctls that may shut down the device */
++	rtnl_lock();
++	len = (*format) (to_net_dev(d), buf);
++	rtnl_unlock();
++	return len;
++}
++
++static ssize_t attr_store(struct device *d,
++			  const char *buf, size_t len,
++			  ssize_t(*set) (struct net_device *, unsigned int),
++			  unsigned int min_val, unsigned int max_val)
++{
++	ssize_t ret;
++	unsigned int val;
++
++	if (!capable(CAP_NET_ADMIN))
++		return -EPERM;
++
++	ret = kstrtouint(buf, 0, &val);
++	if (ret)
++		return ret;
++	if (val < min_val || val > max_val)
++		return -EINVAL;
++
++	rtnl_lock();
++	ret = (*set) (to_net_dev(d), val);
++	if (!ret)
++		ret = len;
++	rtnl_unlock();
++	return ret;
++}
++
++static ssize_t format_pap(struct net_device *dev, char *buf)
++{
++	struct ixgbe_adapter *adapter = netdev_priv(dev);
++	struct ixgbe_hw *hw = &adapter->hw;
++	u32 val;
++	val = IXGBE_READ_REG(hw, IXGBE_PAP) & IXGBE_PAP_PACE_MASK;
++	val >>= 16;
++	return sprintf(buf, "%u\n", val);
++}
++
++static ssize_t show_pap(struct device *d, struct device_attribute *attr,
++			   char *buf)
++{
++	return attr_show(d, buf, format_pap);
++}
++
++static ssize_t set_pap(struct net_device *dev, unsigned int val)
++{
++	struct ixgbe_adapter *adapter = netdev_priv(dev);
++	struct ixgbe_hw *hw = &adapter->hw;
++	u32 reg;
++
++	if ((val < 0) || ((val > 9) && (val != 15)))
++		return -EINVAL;
++
++	reg = IXGBE_READ_REG(hw, IXGBE_PAP);
++	reg &= ~IXGBE_PAP_PACE_MASK;
++	dev_dbg(&dev->dev, "setting pap=%u\n", val);
++	reg |= val << 16;
++	IXGBE_WRITE_REG(hw, IXGBE_PAP, reg);
++
++	return 0;
++}
++
++static ssize_t store_pap(struct device *d, struct device_attribute *attr,
++			      const char *buf, size_t len)
++{
++	return attr_store(d, buf, len, set_pap, 0, 16);
++}
++
++#define IXGBE_ATTR_RW(name, show_method, store_method) \
++static DEVICE_ATTR(name, 0644, show_method, store_method)
++
++IXGBE_ATTR_RW(pap, show_pap, store_pap);
++
++static struct attribute *ixgbe_attrs[] = {
++	&dev_attr_pap.attr,
++	NULL
++};
++
++static const struct attribute_group ixgbe_attr_group = {
++	.attrs = ixgbe_attrs,
++};
++
+ /* called from ixgbe_main.c */
+ void ixgbe_sysfs_exit(struct ixgbe_adapter *adapter)
+ {
+ 	ixgbe_sysfs_del_adapter(adapter);
++	sysfs_remove_group(&adapter->netdev->dev.kobj,
++			   &ixgbe_attr_group);
+ }
+ 
+ /* called from ixgbe_main.c */
+@@ -149,6 +242,14 @@ int ixgbe_sysfs_init(struct ixgbe_adapter *adapter)
+ 	struct device *hwmon_dev;
+ 	unsigned int i;
+ 	int rc = 0;
++	int err;
++
++	err = sysfs_create_group(&adapter->netdev->dev.kobj,
++				 &ixgbe_attr_group);
++	if (err) {
++		dev_err(&adapter->netdev->dev, "cannot create sysfs group\n");
++		goto exit;
++	}
+ 
+ 	/* If this method isn't defined we don't support thermals */
+ 	if (adapter->hw.mac.ops.init_thermal_sensor_thresh == NULL) {
+diff --git a/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h b/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
+index 2b00db92b08f..489ed2b89e82 100644
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
+@@ -1577,6 +1577,7 @@ enum {
+ 
+ /* PAP bit masks*/
+ #define IXGBE_PAP_TXPAUSECNT_MASK   0x0000FFFF /* Pause counter mask */
++#define IXGBE_PAP_PACE_MASK         0x000F0000 /* Pace bit mask */
+ 
+ /* RMCS Bit Masks */
+ #define IXGBE_RMCS_RRM          0x00000002 /* Receive Recycle Mode enable */


### PR DESCRIPTION
This pull request includes the following changes:

- Enable ipgen to set TIPG and PAP to devices on Linux
- Changes to the ixgbe and igb drivers to:
  - Allow TIPG and PAP settings for devices
  - Provide a sysfs interface for passing TIPG/PAP values to the driver
- ipgen now builds with libxdp instead of libbpf
- Various bug fixes

The PAP setting feature has been tested on Fedora 37 with X550, while the TIPG setting feature has only been verified as buildable.

Additionally, the branch has been checked for buildability on FreeBSD 13.1.