### PR TITLE
Add and modify function prototypes and definitions, use static for static functions, remove unused, sprinkle const and add -W flags.

### DIFF
--- a/gen/GNUmakefile
+++ b/gen/GNUmakefile
@@ -4,6 +4,8 @@ PROG=		ipgen
 SRCS=		gen.c util.c webserv.c pbuf.c sequencecheck.c seqtable.c item.c genscript.c flowparse.c pktgen_item.c
 CFLAGS+=	-I.. -I/usr/local/include -g -DHTDOCS=\"${PREFIX}/share/ipgen/htdocs\"
 CFLAGS+=	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith
+CFLAGS+=	-Wreturn-type -Wswitch # -Wshadow XXX for gen.c
+CFLAGS+=	-Wcast-qual -Wwrite-strings
 LDADD=		-L../libpkt -lpkt -L../libaddrlist -L/usr/local/lib -laddrlist -lpthread -lc -lcurses -levent -lmd
 
 ifeq ($(shell uname),Linux)

--- a/gen/GNUmakefile
+++ b/gen/GNUmakefile
@@ -2,7 +2,8 @@ include ../Makefile.inc
 
 PROG=		ipgen
 SRCS=		gen.c util.c webserv.c pbuf.c sequencecheck.c seqtable.c item.c genscript.c flowparse.c pktgen_item.c
-CFLAGS+=	-I.. -I/usr/local/include -g -Wall -DHTDOCS=\"${PREFIX}/share/ipgen/htdocs\"
+CFLAGS+=	-I.. -I/usr/local/include -g -DHTDOCS=\"${PREFIX}/share/ipgen/htdocs\"
+CFLAGS+=	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith
 LDADD=		-L../libpkt -lpkt -L../libaddrlist -L/usr/local/lib -laddrlist -lpthread -lc -lcurses -levent -lmd
 
 ifeq ($(shell uname),Linux)

--- a/gen/arpresolv.c
+++ b/gen/arpresolv.c
@@ -547,7 +547,7 @@ ndpresolv(const char *ifname, int vlan, struct in6_addr *src, struct in6_addr *d
 }
 
 static int
-bpfslot()
+bpfslot(void)
 {
 	int fd, i;
 

--- a/gen/flowparse.c
+++ b/gen/flowparse.c
@@ -36,6 +36,9 @@
 #include "flowparse.h"
 #include "util.h"
 
+static int parse_addr6_port(char *, struct in6_addr *, struct in6_addr *,
+    uint16_t *, uint16_t *);
+
 /*
  * parse "12345-23456"
  *       "12345"

--- a/gen/flowparse.c
+++ b/gen/flowparse.c
@@ -155,7 +155,7 @@ parse_addr_port(char *str, struct in_addr *addrstart, struct in_addr *addrend, u
 	return 0;
 }
 
-int
+static int
 parse_addr6_port(char *str, struct in6_addr *addr6start, struct in6_addr *addr6end, uint16_t *portstart, uint16_t *portend)
 {
 	char *p0, *p;

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -3490,9 +3490,6 @@ static void
 evt_timeout_callback(evutil_socket_t fd, short event, void *arg)
 {
 	struct itemlist *itemlist;
-	static int nth = 0;
-
-	nth++;
 
 	if (do_quit) {
 		quit(false);

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -376,7 +376,7 @@ struct timespec currenttime_main;
 struct timespec starttime_tx;
 sigset_t used_sigset;
 
-unsigned int
+static unsigned int
 build_template_packet_ipv4(int ifno, char *pkt)
 {
 	if (ifno == 0) {
@@ -396,7 +396,7 @@ build_template_packet_ipv4(int ifno, char *pkt)
 	return interface[ifno].pktsize;
 }
 
-unsigned int
+static unsigned int
 build_template_packet_ipv6(int ifno, char *pkt)
 {
 	if (ifno == 0) {
@@ -476,7 +476,7 @@ pktcpy_pppoe(char *dstbuf, char *srcbuf, unsigned int pktsize, uint16_t session,
 }
 #endif
 
-void
+static void
 touchup_tx_packet(char *buf, int ifno)
 {
 	struct interface *iface = &interface[ifno];
@@ -592,7 +592,7 @@ touchup_tx_packet(char *buf, int ifno)
 	}
 }
 
-int
+static int
 packet_generator(char *buf, int ifno)
 {
 	struct interface *iface = &interface[ifno];
@@ -626,7 +626,7 @@ statistics_clear(void)
 }
 
 #ifdef __linux__
-int
+static int
 getdrvname(const char *ifname, char *drvname)
 {
 	ssize_t n;
@@ -649,7 +649,7 @@ getdrvname(const char *ifname, char *drvname)
 	return 0;
 }
 #else
-int
+static int
 getifunit(const char *ifname, char *drvname, unsigned long *unit)
 {
 	int i;
@@ -1100,7 +1100,7 @@ transmit_set(int ifno, int on)
 	update_transmit_Mbps(ifno);
 }
 
-void
+static void
 interface_wait_linkup(const char *ifname)
 {
 	int i;
@@ -1122,14 +1122,14 @@ interface_wait_linkup(const char *ifname)
 	fflush(stdout);
 }
 
-void
+static void
 interface_init(int ifno)
 {
 	interface[ifno].seqtable = seqtable_new();
 	interface[ifno].seqchecker = seqcheck_new();
 }
 
-void
+static void
 interface_setup(int ifno, const char *ifname)
 {
 	struct interface *iface = &interface[ifno];
@@ -1207,7 +1207,7 @@ interface_setup(int ifno, const char *ifname)
 	}
 }
 
-void
+static void
 interface_open(int ifno)
 {
 	struct interface *iface = &interface[ifno];
@@ -1312,7 +1312,7 @@ interface_close(int ifno)
 	}
 }
 
-int
+static int
 interface_need_transmit(int ifno)
 {
 	int n;
@@ -1325,7 +1325,7 @@ interface_need_transmit(int ifno)
 	return n;
 }
 
-int
+static int
 interface_load_transmit_packet(int ifno, char *buf, uint16_t *lenp)
 {
 	struct interface *iface = &interface[ifno];
@@ -1363,7 +1363,7 @@ interface_load_transmit_packet(int ifno, char *buf, uint16_t *lenp)
 	return -1;
 }
 
-void
+static void
 icmpecho_handler(int ifno, char *pkt, int len, int l3offset)
 {
 	struct interface *iface = &interface[ifno];
@@ -1386,7 +1386,7 @@ icmpecho_handler(int ifno, char *pkt, int len, int l3offset)
 	}
 }
 
-void
+static void
 arp_handler(int ifno, char *pkt, int l3offset)
 {
 	struct interface *iface = &interface[ifno];
@@ -1481,7 +1481,7 @@ ndp_handler(int ifno, char *pkt, int l3offset)
 }
 
 #ifdef SUPPORT_PPPOE
-int
+static int
 pppoe_handler(int ifno, char *pkt)
 {
 	struct pppoe_l2 *req;
@@ -1536,7 +1536,7 @@ pppoe_handler(int ifno, char *pkt)
 }
 #endif
 
-void
+static void
 receive_packet(int ifno, struct timespec *curtime, char *buf, uint16_t len)
 {
 	struct interface *iface = &interface[ifno];
@@ -1721,7 +1721,7 @@ receive_packet(int ifno, struct timespec *curtime, char *buf, uint16_t len)
 	}
 }
 
-void
+static void
 interface_receive(int ifno)
 {
 	struct interface *iface = &interface[ifno];
@@ -2316,7 +2316,7 @@ logging(char const *fmt, ...)
 }
 
 
-void *
+static void *
 tx_thread_main(void *arg)
 {
 	int ifno = *(int *)arg;
@@ -2347,7 +2347,7 @@ tx_thread_main(void *arg)
 	return NULL;
 }
 
-void *
+static void *
 rx_thread_main(void *arg)
 {
 	int ifno = *(int *)arg;
@@ -2387,7 +2387,7 @@ rx_thread_main(void *arg)
 
 
 
-void
+static void
 genscript_play(int unsigned n)
 {
 	static int nth_test = -1;
@@ -2535,7 +2535,7 @@ typedef enum {
 	RFC2544_DONE
 } rfc2544_state_t;
 
-void
+static void
 rfc2544_add_test(uint64_t maxlinkspeed, unsigned int pktsize)
 {
 	struct rfc2544_work *work = &rfc2544_work[rfc2544_ntest];
@@ -2557,7 +2557,7 @@ rfc2544_add_test(uint64_t maxlinkspeed, unsigned int pktsize)
 	rfc2544_ntest++;
 }
 
-void
+static void
 rfc2544_load_default_test(uint64_t maxlinkspeed)
 {
 	rfc2544_ntest = 0;	/* clear table */
@@ -2570,7 +2570,7 @@ rfc2544_load_default_test(uint64_t maxlinkspeed)
 	rfc2544_add_test(maxlinkspeed, 1518 - ETHHDRSIZE - FCS);
 }
 
-void
+static void
 rfc2544_calc_param(uint64_t maxlinkspeed)
 {
 	int i;
@@ -2842,8 +2842,8 @@ rfc2544_up_pps(void)
 	return 0;
 }
 
-void
-rfc2544_test(int unsigned n)
+static void
+rfc2544_test(unsigned int n)
 {
 	struct rfc2544_work *work = &rfc2544_work[rfc2544_nthtest];
 	static rfc2544_state_t state = RFC2544_START;
@@ -3279,7 +3279,7 @@ itemlist_callback_startstop(struct itemlist *itemlist, struct item *item, void *
 	return 0;
 }
 
-void
+static void
 control_init_items(struct itemlist *itemlist)
 {
 	static char ipgen_api[16];
@@ -3466,7 +3466,7 @@ evt_timeout_callback(evutil_socket_t fd, short event, void *arg)
 }
 
 
-void *
+static void *
 control_thread_main(void *arg)
 {
 	struct event ev_tty;
@@ -3501,7 +3501,7 @@ control_thread_main(void *arg)
 	return NULL;
 }
 
-void
+static void
 gentest_main(void)
 {
 	time_t lastsec = 0;
@@ -3658,7 +3658,7 @@ parse_address(const int ifno, char *s)
 	}
 }
 
-void
+static void
 generate_addrlists(void)
 {
 	int rc;

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -376,6 +376,44 @@ struct timespec currenttime_main;
 struct timespec starttime_tx;
 sigset_t used_sigset;
 
+static unsigned int build_template_packet_ipv4(int, char *);
+static unsigned int build_template_packet_ipv6(int, char *);
+static void touchup_tx_packet(char *, int);
+static int packet_generator(char *, int);
+#ifdef __linux__
+static int getdrvname(const char *, char *);
+#else
+static int getifunit(const char *, char *, unsigned long *);
+#endif
+static void interface_wait_linkup(const char *);
+static void interface_init(int);
+static void interface_setup(int, const char *);
+static void interface_open(int);
+static void interface_close(int);
+static int interface_need_transmit(int);
+static int interface_load_transmit_packet(int, char *, uint16_t *);
+static void icmpecho_handler(int, char *, int, int);
+static void arp_handler(int, char *, int);
+static void ndp_handler(int, char *, int);
+#ifdef SUPPORT_PPPOE
+static int pppoe_handler(int, char *);
+#endif
+static void receive_packet(int, struct timespec *, char *, uint16_t);
+static void interface_receive(int);
+static int interface_transmit(int);
+static void *tx_thread_main(void *);
+static void *rx_thread_main(void *);
+static void genscript_play(int unsigned);
+static void rfc2544_add_test(uint64_t, unsigned int);
+static void rfc2544_load_default_test(uint64_t);
+static void rfc2544_calc_param(uint64_t);
+static void rfc2544_test(int unsigned);
+static void control_init_items(struct itemlist *);
+static void *control_thread_main(void *);
+static void gentest_main(void);
+static void generate_addrlists(void);
+
+
 static unsigned int
 build_template_packet_ipv4(int ifno, char *pkt)
 {

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -602,9 +602,9 @@ touchup_tx_packet(char *buf, int ifno)
 		}
 
 		if (iface->gw_l2random)
-			ethpkt_dst(buf, (u_char *)tuple->deaddr.octet);
+			ethpkt_dst(buf, (const u_char *)tuple->deaddr.octet);
 		if (iface_other->gw_l2random)
-			ethpkt_src(buf, (u_char *)tuple->seaddr.octet);
+			ethpkt_src(buf, (const u_char *)tuple->seaddr.octet);
 
 		if (ipv6)
 			l4payloadsize = iface->pktsize - sizeof(struct ip6_hdr);

--- a/gen/genscript.h
+++ b/gen/genscript.h
@@ -45,7 +45,7 @@ struct genscript {
 static inline const char *
 genscript_cmdname(unsigned int cmd)
 {
-	char *cmd2cmdname[] = {
+	const char *cmd2cmdname[] = {
 		"RESET", "NOP", "TX0", "TX1"
 	};
 	if (cmd >= GENITEM_CMD_NCMD)

--- a/gen/item.c
+++ b/gen/item.c
@@ -75,7 +75,7 @@ static int itemlist_status(struct itemlist *);
 #define ITEMLIST_STATUS_FOCUS	1
 #define ITEMLIST_STATUS_EDITING	2
 
-static void item_setvalue(struct item *, void *);
+static void item_setvalue(struct item *, const void *);
 static void itemlist_update_editing(struct itemlist *, int);
 static int itemlist_editstart(struct itemlist *);
 static int itemlist_editor(struct itemlist *, int c);
@@ -473,7 +473,7 @@ itemlist_register_item(struct itemlist *itemlist, int id, int (*cb_apply)(struct
 }
 
 static void
-item_setvalue_str(struct item *item, char *str)
+item_setvalue_str(struct item *item, const char *str)
 {
 	strncpy(item->disp.str, str, sizeof(item->disp.str));
 }
@@ -491,7 +491,7 @@ item_setvalue_double(struct item *item, double dbl)
 }
 
 static void
-item_setvalue(struct item *item, void *valueptr)
+item_setvalue(struct item *item, const void *valueptr)
 {
 	if (valueptr == NULL) {
 		item->disp.num = 0;
@@ -501,19 +501,19 @@ item_setvalue(struct item *item, void *valueptr)
 			item_setvalue_str(item, valueptr);
 			break;
 		case ITEMTYPE_UINT8:
-			item_setvalue_num(item, *(uint8_t *)valueptr);
+			item_setvalue_num(item, *(const uint8_t *)valueptr);
 			break;
 		case ITEMTYPE_UINT16:
-			item_setvalue_num(item, *(uint16_t *)valueptr);
+			item_setvalue_num(item, *(const uint16_t *)valueptr);
 			break;
 		case ITEMTYPE_UINT32:
-			item_setvalue_num(item, *(uint32_t *)valueptr);
+			item_setvalue_num(item, *(const uint32_t *)valueptr);
 			break;
 		case ITEMTYPE_UINT64:
-			item_setvalue_num(item, *(uint64_t *)valueptr);
+			item_setvalue_num(item, *(const uint64_t *)valueptr);
 			break;
 		case ITEMTYPE_DOUBLE:
-			item_setvalue_double(item, *(double *)valueptr);
+			item_setvalue_double(item, *(const double *)valueptr);
 			break;
 		}
 	}
@@ -521,7 +521,7 @@ item_setvalue(struct item *item, void *valueptr)
 }
 
 void
-itemlist_setvalue(struct itemlist *itemlist, int id, void *valueptr)
+itemlist_setvalue(struct itemlist *itemlist, int id, const void *valueptr)
 {
 	struct item *item;
 

--- a/gen/item.h
+++ b/gen/item.h
@@ -81,7 +81,7 @@ int itemlist_init_term(void);
 int itemlist_fini_term(void);
 
 void itemlist_register_item(struct itemlist *, int, int (*)(struct itemlist *, struct item *, void *), void *);
-void itemlist_setvalue(struct itemlist *, int, void *);
+void itemlist_setvalue(struct itemlist *, int, const void *);
 void itemlist_focus(struct itemlist *, int);
 void itemlist_editable(struct itemlist *, int, int);
 

--- a/gen/netmap_user_localdebug.h
+++ b/gen/netmap_user_localdebug.h
@@ -231,7 +231,7 @@ struct nm_desc {
  * when the descriptor is open correctly, d->self == d
  * Eventually we should also use some magic number.
  */
-#define P2NMD(p)		((struct nm_desc *)(p))
+#define P2NMD(p)		((const struct nm_desc *)(p))
 #define IS_NETMAP_DESC(d)	((d) && P2NMD(d)->self == P2NMD(d))
 #define NETMAP_FD(d)		(P2NMD(d)->fd)
 

--- a/gen/pppoe.c
+++ b/gen/pppoe.c
@@ -250,7 +250,6 @@ recv_pppoe(void *arg, int fd, char *buf, int buflen, const char *ifname)
 {
 	struct pppoe_softc *sc;
 	struct pppoe_l2 *req;
-	struct pppoeppp *pppreq;
 	char pktbuf[2048];
 	unsigned char pppopt[128];
 	uint16_t etype;
@@ -264,7 +263,6 @@ recv_pppoe(void *arg, int fd, char *buf, int buflen, const char *ifname)
 #endif
 
 	req = (struct pppoe_l2 *)buf;
-	pppreq = (struct pppoeppp *)(req + 1);
 
 	/* ignore packets sent by itself */
 	if (memcmp(&sc->srcmac, req->eheader.ether_shost, ETHER_ADDR_LEN) == 0)
@@ -526,10 +524,7 @@ pppoe_server(const char *ifname, struct pppoe_softc *sc)
 	fd_set rfd;
 	struct timeval tlim;
 	struct ether_addr macaddr;
-	struct ether_addr *found;
 	int fd, rc, mtu, error, established = 0;
-
-	found = NULL;
 
 	fd = bpfopen(ifname, 0, &bpfbuflen);
 	if (fd < 0) {

--- a/gen/pppoe.c
+++ b/gen/pppoe.c
@@ -627,7 +627,7 @@ main(int argc, char *argv[])
 
 
 static int
-bpfslot()
+bpfslot(void)
 {
 	int fd;
 

--- a/gen/pppoe.c
+++ b/gen/pppoe.c
@@ -112,7 +112,7 @@ strmacaddr(const uint8_t *eth)
 	return buf;
 }
 
-static char *
+const static char *
 strpppoecode(uint8_t code)
 {
 	static char buf[sizeof("0x00")];
@@ -134,7 +134,7 @@ strpppoecode(uint8_t code)
 	return buf;
 }
 
-static char *
+const static char *
 strpppproto(uint16_t proto)
 {
 	static char buf[sizeof("0x0000")];
@@ -161,7 +161,7 @@ strpppproto(uint16_t proto)
 	return NULL;
 }
 
-static char *
+const static char *
 strlcptype(uint8_t type)
 {
 	static char buf[sizeof("0x0000")];

--- a/gen/util.c
+++ b/gen/util.c
@@ -337,7 +337,7 @@ getiflinkaddr(const char *ifname, struct ether_addr *addr)
 			if ((sdl->sdl_type == IFT_ETHER) &&
 			    (sdl->sdl_alen == ETHER_ADDR_LEN)) {
 
-				memcpy(addr, (struct ether_addr *)LLADDR(sdl), ETHER_ADDR_LEN);
+				memcpy(addr, (const struct ether_addr *)CLLADDR(sdl), ETHER_ADDR_LEN);
 				found = 1;
 				break;
 			}

--- a/gen/webserv.c
+++ b/gen/webserv.c
@@ -36,7 +36,7 @@
 #include "gen.h"
 
 static int webserv_output(struct webserv *, char *, int);
-static int webserv_reply_errcode(struct webserv *, int, char *);
+static int webserv_reply_errcode(struct webserv *, int, const char *);
 static int webserv_stream(struct webserv *, char *, int);
 static int webserv_read(struct webserv *);
 static int webserv_connected(struct webserv *);
@@ -52,7 +52,7 @@ static int pathhandler(struct webserv *, char *);
 #ifndef HTDOCS
 #define HTDOCS	"../htdocs/"
 #endif
-char *htdocs;
+const char *htdocs;
 
 
 #define	HTTP_FOUND_APPLICATION_JSON			\
@@ -327,7 +327,7 @@ webserv_new(int fd)
 }
 
 static int
-webserv_reply_errcode(struct webserv *web, int status, char *string)
+webserv_reply_errcode(struct webserv *web, int status, const char *string)
 {
 	fprintf(web->fh, "HTTP/1.0 %03d %s\r\n\r\n%03d %s\n",
 	    status, string, status, string);

--- a/gen/webserv.c
+++ b/gen/webserv.c
@@ -212,7 +212,7 @@ handler_interface(struct webserv *web, const char *path, int argc, char *argv[])
 	return 0;
 }
 
-int
+static int
 pathhandler(struct webserv *web, char *path)
 {
 	struct urlhandler *match;

--- a/gen/webserv.c
+++ b/gen/webserv.c
@@ -46,6 +46,7 @@ static int handler_index(struct webserv *, const char *path, int argc, char *arg
 static int handler_stat(struct webserv *, const char *path, int argc, char *argv[]);
 static int handler_clear(struct webserv *, const char *path, int argc, char *argv[]);
 static int handler_interface(struct webserv *, const char *path, int argc, char *argv[]);
+static int pathhandler(struct webserv *, char *);
 
 
 #ifndef HTDOCS

--- a/libaddrlist/GNUmakefile
+++ b/libaddrlist/GNUmakefile
@@ -4,7 +4,7 @@ TARGETLIB=	libaddrlist.a
 SRCS+=		addresses.c
 
 CFLAGS+=	-O2
-CFLAGS+=	-Wall
+CFLAGS+=	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith
 CFLAGS+=	-Wno-address-of-packed-member
 
 OBJS+=	$(SRCS:%.c=%.o)

--- a/libaddrlist/GNUmakefile
+++ b/libaddrlist/GNUmakefile
@@ -5,6 +5,8 @@ SRCS+=		addresses.c
 
 CFLAGS+=	-O2
 CFLAGS+=	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith
+CFLAGS+=	-Wreturn-type -Wswitch -Wshadow
+CFLAGS+=	-Wcast-qual -Wwrite-strings
 CFLAGS+=	-Wno-address-of-packed-member
 
 OBJS+=	$(SRCS:%.c=%.o)

--- a/libaddrlist/addresses.c
+++ b/libaddrlist/addresses.c
@@ -601,7 +601,7 @@ addresslist_dump(struct addresslist *adrlist)
 	unsigned int n;
 	char buf1[128], buf2[128];
 	char ebuf1[sizeof("00:00:00:00:00:00")], ebuf2[sizeof("00:00:00:00:00:00")];
-	char *bracket_l, *bracket_r;
+	const char *bracket_l, *bracket_r;
 
 	printf("<addresslist p=%p sorted=%d ntuple=%u curtuple=%u>\n",
 	    adrlist, adrlist->sorted,

--- a/libpkt/GNUmakefile
+++ b/libpkt/GNUmakefile
@@ -10,6 +10,8 @@ SRCS+=		utils.c
 
 CFLAGS+=	-O2
 CFLAGS+=	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith
+CFLAGS+=	-Wreturn-type -Wswitch -Wshadow
+CFLAGS+=	-Wcast-qual -Wwrite-strings
 CFLAGS+=	-Wno-address-of-packed-member
 
 # x86

--- a/libpkt/GNUmakefile
+++ b/libpkt/GNUmakefile
@@ -9,7 +9,7 @@ SRCS+=		ip6pkt.c
 SRCS+=		utils.c
 
 CFLAGS+=	-O2
-CFLAGS+=	-Wall
+CFLAGS+=	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith
 CFLAGS+=	-Wno-address-of-packed-member
 
 # x86

--- a/libpkt/etherpkt.c
+++ b/libpkt/etherpkt.c
@@ -50,7 +50,7 @@ ethpkt_type(char *buf, u_short type)
 }
 
 int
-ethpkt_src(char *buf, u_char *eaddr)
+ethpkt_src(char *buf, const u_char *eaddr)
 {
 	struct ether_header *eh;
 
@@ -60,7 +60,7 @@ ethpkt_src(char *buf, u_char *eaddr)
 }
 
 int
-ethpkt_dst(char *buf, u_char *eaddr)
+ethpkt_dst(char *buf, const u_char *eaddr)
 {
 	struct ether_header *eh;
 

--- a/libpkt/ip4pkt.c
+++ b/libpkt/ip4pkt.c
@@ -693,7 +693,7 @@ ip4pkt_getptr(char *buf, unsigned int l3offset, unsigned int offset)
 	return datap;
 }
 
-int
+static int
 ip4pkt_icmp_uint8(char *buf, unsigned int l3offset, int icmpoffset, uint8_t data)
 {
 	struct ip *ip;
@@ -732,7 +732,7 @@ ip4pkt_icmp_uint8(char *buf, unsigned int l3offset, int icmpoffset, uint8_t data
 	return 0;
 }
 
-int
+static int
 ip4pkt_icmp_uint16(char *buf, unsigned int l3offset, int icmpoffset, uint16_t data)
 {
 	struct ip *ip;

--- a/libpkt/ip4pkt.c
+++ b/libpkt/ip4pkt.c
@@ -41,6 +41,9 @@
 #define IPPROTO_IPV4	4
 #endif
 
+static int ip4pkt_icmp_uint8(char *, unsigned int, int, uint8_t);
+static int ip4pkt_icmp_uint16(char *, unsigned int, int, uint16_t);
+
 int
 ip4pkt_arpparse(char *buf, int *op, struct ether_addr *sha, in_addr_t *spa, in_addr_t *tpa)
 {

--- a/libpkt/ip4pkt.c
+++ b/libpkt/ip4pkt.c
@@ -89,13 +89,14 @@ ip4pkt_arpquery(char *buf, const struct ether_addr *sha, in_addr_t spa, in_addr_
 int
 ip4pkt_arpreply(char *buf, const char *querybuf, u_char *eaddr, in_addr_t addr, in_addr_t mask)
 {
-	struct ether_header *eheader;
-	struct ether_vlan_header *evheader = NULL;
-	struct arppkt_l2 *aquery, *areply;
+	const struct ether_header *eheader;
+	const struct ether_vlan_header *evheader = NULL;
+	const struct arppkt_l2 *aquery;
+	struct arppkt_l2 *areply;
 	uint16_t etype;
 
-	eheader = (struct ether_header *)querybuf;
-	aquery = (struct arppkt_l2 *)querybuf;
+	eheader = (const struct ether_header *)querybuf;
+	aquery = (const struct arppkt_l2 *)querybuf;
 	areply = (struct arppkt_l2 *)buf;
 
 	static const uint8_t eth_broadcast[ETHER_ADDR_LEN] =
@@ -103,7 +104,7 @@ ip4pkt_arpreply(char *buf, const char *querybuf, u_char *eaddr, in_addr_t addr, 
 
 	etype = ntohs(eheader->ether_type);
 	if (etype == ETHERTYPE_VLAN) {
-		evheader = (struct ether_vlan_header *)eheader;
+		evheader = (const struct ether_vlan_header *)eheader;
 		etype = ntohs(evheader->evl_proto);
 	}
 
@@ -187,10 +188,11 @@ ip4pkt_icmp_template(char *buf, unsigned int framelen)
 int
 ip4pkt_icmp_echoreply(char *buf, unsigned int l3offset, const char *reqbuf, unsigned int framelen)
 {
-	struct ip *ip, *rip;
+	struct ip *ip;
+	const struct ip *rip;
 
 	ip = (struct ip *)(buf + l3offset);
-	rip = (struct ip *)(reqbuf + l3offset);
+	rip = (const struct ip *)(reqbuf + l3offset);
 
 	memcpy(buf, reqbuf, framelen);
 	ip->ip_src = rip->ip_dst;

--- a/libpkt/ip6pkt.c
+++ b/libpkt/ip6pkt.c
@@ -97,7 +97,7 @@ ip6pkt_neighbor_solicit(char *buf, const struct ether_addr *sha, struct in6_addr
 	ip6len = len - sizeof(struct ether_header);
 	protolen = ip6len - sizeof(struct ip6_hdr);
 
-	ethpkt_src(buf, (u_char *)sha);
+	ethpkt_src(buf, (const u_char *)sha);
 	ethpkt_dst(buf, edst);
 
 	memset(&daddr, 0, sizeof(daddr));
@@ -152,21 +152,21 @@ ip6pkt_neighbor_parse(char *buf, int *type, struct in6_addr *src, struct in6_add
 int
 ip6pkt_neighbor_solicit_reply(char *buf, const char *solicitbuf, u_char *eaddr, struct in6_addr *addr)
 {
-	struct ether_header *oeheader;
-	struct ether_vlan_header *oevheader;
-	struct ndpkt_l3 *ondpkt_l3;
+	const struct ether_header *oeheader;
+	const struct ether_vlan_header *oevheader;
+	const struct ndpkt_l3 *ondpkt_l3;
 	struct ndpkt_l2 *ndpkt_l2;
 	unsigned int ip6len, protolen;
 	int len;
 
-	oeheader = (struct ether_header *)solicitbuf;
+	oeheader = (const struct ether_header *)solicitbuf;
 	ndpkt_l2 = (struct ndpkt_l2 *)buf;
 
 	if (ntohs(oeheader->ether_type) == ETHERTYPE_VLAN) {
-		ondpkt_l3 = (struct ndpkt_l3 *)(solicitbuf + sizeof(struct ether_vlan_header));
-		oevheader = (struct ether_vlan_header *)oeheader;
+		ondpkt_l3 = (const struct ndpkt_l3 *)(solicitbuf + sizeof(struct ether_vlan_header));
+		oevheader = (const struct ether_vlan_header *)oeheader;
 	} else {
-		ondpkt_l3 = (struct ndpkt_l3 *)(solicitbuf + sizeof(struct ether_header));
+		ondpkt_l3 = (const struct ndpkt_l3 *)(solicitbuf + sizeof(struct ether_header));
 		oevheader = NULL;
 	}
 
@@ -248,10 +248,11 @@ ip6pkt_icmp6_template(char *buf, unsigned int framelen)
 int
 ip6pkt_icmp6_echoreply(char *buf, unsigned int l3offset, const char *reqbuf, unsigned int framelen)
 {
-	struct ip6_hdr *ip6, *rip6;
+	struct ip6_hdr *ip6;
+	const struct ip6_hdr *rip6;
 
 	ip6 = (struct ip6_hdr *)(buf + l3offset);
-	rip6 = (struct ip6_hdr *)(reqbuf + l3offset);
+	rip6 = (const struct ip6_hdr *)(reqbuf + l3offset);
 
 	memcpy(buf, reqbuf, framelen);
 	memcpy(&ip6->ip6_src, &rip6->ip6_dst, sizeof(struct in6_addr));

--- a/libpkt/ip6pkt.c
+++ b/libpkt/ip6pkt.c
@@ -79,6 +79,9 @@
 #define s6_addr32 __u6_addr.__u6_addr32
 #endif
 
+static int ip6pkt_icmp_uint8(char *, unsigned int, int, uint8_t);
+static int ip6pkt_icmp_uint16(char *, unsigned int, int, uint16_t);
+
 int
 ip6pkt_neighbor_solicit(char *buf, const struct ether_addr *sha, struct in6_addr *addr1, struct in6_addr *addr2)
 {

--- a/libpkt/ip6pkt.c
+++ b/libpkt/ip6pkt.c
@@ -778,7 +778,7 @@ ip6pkt_getptr(char *buf, unsigned int l3offset, unsigned int offset)
 	return datap;
 }
 
-int
+static int
 ip6pkt_icmp_uint8(char *buf, unsigned int l3offset, int icmpoffset, uint8_t data)
 {
 	struct ip6_hdr *ip6;
@@ -819,7 +819,7 @@ ip6pkt_icmp_uint8(char *buf, unsigned int l3offset, int icmpoffset, uint8_t data
 	return 0;
 }
 
-int
+static int
 ip6pkt_icmp_uint16(char *buf, unsigned int l3offset, int icmpoffset, uint16_t data)
 {
 	struct ip6_hdr *ip6;

--- a/libpkt/libpkt.h
+++ b/libpkt/libpkt.h
@@ -217,8 +217,8 @@ unsigned int in_cksum(unsigned int, char *, unsigned int);
 /* etherpkt.c */
 int ethpkt_template(char *, unsigned int);
 int ethpkt_type(char *, u_short);
-int ethpkt_src(char *, u_char *);
-int ethpkt_dst(char *, u_char *);
+int ethpkt_src(char *, const u_char *);
+int ethpkt_dst(char *, const u_char *);
 
 /* pppoepkt.c */
 int pppoepkt_template(char *, uint16_t);
@@ -228,7 +228,7 @@ int pppoepkt_session(char *, uint16_t);
 int pppoepkt_type(char *, uint16_t);
 int pppoepkt_length(char *, uint16_t);
 int pppoepkt_tag_extract(char *, uint16_t, void *, uint16_t *);
-int pppoepkt_tag_add(char *, uint16_t, void *, uint16_t);
+int pppoepkt_tag_add(char *, uint16_t, const void *, uint16_t);
 int pppoepkt_ppp_set(char *, uint16_t, uint8_t, uint8_t);
 int pppoepkt_ppp_extract_data(char *, int, void *, int);
 int pppoepkt_ppp_add_data(char *, void *, uint16_t);

--- a/libpkt/pppoepkt.c
+++ b/libpkt/pppoepkt.c
@@ -124,7 +124,7 @@ pppoepkt_tag_extract(char *buf, uint16_t tag, void *data, uint16_t *datalen)
 }
 
 int
-pppoepkt_tag_add(char *buf, uint16_t tag, void *data, uint16_t datalen)
+pppoepkt_tag_add(char *buf, uint16_t tag, const void *data, uint16_t datalen)
 {
 	struct pppoe_l2 *pppoe;
 	struct pppoetag *pppoetag;

--- a/libpkt/utils.c
+++ b/libpkt/utils.c
@@ -23,6 +23,9 @@
  * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "libpkt.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
Added the following flags:
-Wstrict-prototypes
-Wmissing-prototypes
-Wpointer-arith
-Wreturn-type
-Wswitch
-Wcast-qual
-Wwrite-strings
-Wshadow

For -Wshadow, it's disabled in gen/GNUmakefile because gen.c have to modify shadowing.

Tested on freebsd 12, 13 and 14.