### PR TITLE
Update description of --ipg in the help message.

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2263,7 +2263,7 @@ usage(void)
 	       "\n"
 	       "	-H <Hz>				specify control Hz (default: 1000)\n"
 	       "	-n <npkt>			sync transmit per <npkt>\n"
-	       "	--ipg				adapt IPG (Inter Packet Gap) if possible\n"
+	       "	--ipg				adapt IPG (Inter Packet Gap)\n"
 	       "	--burst				don't set IPG (default)\n"
 	       "\n"
 	       "	-S <script>			autotest script\n"


### PR DESCRIPTION
 Commit 25083d913534723757bbdd8fdecdb00934840a39 changed the behavior
of --ipg. It returns with error if --ipg is set but neither TIPG nor PAP are supported. So remove "if possible" from the description.