### PR TITLE
Accept the PAP feature on Denverton, too.

### DIFF
--- a/patch/ix-pacing-freebsd12.3.dif
+++ b/patch/ix-pacing-freebsd12.3.dif
@@ -72,7 +72,7 @@ index 581944fa6a7..7274358644d 100644
 +		    CTLTYPE_INT | CTLFLAG_RW, sc, 0,
 +			ixgbe_sysctl_tipg, "I", "Transmit IPG register");
 +
-+	else if (hw->mac.type <= ixgbe_mac_X550EM_x)
++	else if (hw->mac.type <= ixgbe_mac_X550EM_a)
 +		SYSCTL_ADD_PROC(ctx_list, child, OID_AUTO, "pap",
 +			CTLTYPE_INT | CTLFLAG_RW, sc, 0,
 +			ixgbe_sysctl_pap, "I", "Pause and Pace register");

--- a/patch/ix-pacing-freebsd13.0.dif
+++ b/patch/ix-pacing-freebsd13.0.dif
@@ -75,7 +75,7 @@ index 9f3674cdab5..c0f59044be7 100644
 +		    adapter, 0,
 +		    ixgbe_sysctl_tipg, "I", "Transmit IPG register");
 +
-+	else if (hw->mac.type <= ixgbe_mac_X550EM_x)
++	else if (hw->mac.type <= ixgbe_mac_X550EM_a)
 +		SYSCTL_ADD_PROC(ctx_list, child, OID_AUTO, "pap",
 +		    CTLTYPE_INT | CTLFLAG_RW | CTLFLAG_NEEDGIANT,
 +		    adapter, 0,

--- a/patch/ix-pacing-freebsd13.1.dif
+++ b/patch/ix-pacing-freebsd13.1.dif
@@ -74,7 +74,7 @@ index 3077fc9ac4f..5f6ae7ca8ab 100644
 +		    CTLTYPE_INT | CTLFLAG_RW | CTLFLAG_NEEDGIANT,
 +		    sc, 0, ixgbe_sysctl_tipg, "I",
 +		    "Transmit IPG register");
-+	else if (hw->mac.type <= ixgbe_mac_X550EM_x)
++	else if (hw->mac.type <= ixgbe_mac_X550EM_a)
 +		SYSCTL_ADD_PROC(ctx_list, child, OID_AUTO, "pap",
 +		    CTLTYPE_INT | CTLFLAG_RW | CTLFLAG_NEEDGIANT,
 +		    sc, 0, ixgbe_sysctl_pap, "I",


### PR DESCRIPTION
 Fix a long standing bug that dev.ix.N.pap sysctl is not created on
Denverton.