### PR TITLE
Fix wrong memset in main().

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -3927,7 +3927,6 @@ main(int argc, char *argv[])
 	/* initialize instances */
 	pps = -1;
 	for (i = 0; i < 2; i++) {
-		memset(&interface[i], 0, sizeof(interface));
 		interface_init(i);
 		pbufq_init(&interface[i].pbufq);
 		interface[i].pktsize = min_pktsize;


### PR DESCRIPTION
 memset(&interface[i], 0, sizeof(interface)) is wrong because
sizeof(interface) != sizeof(interface[i]). The interface[] is in BSS, so it's not required to initialize it explicitly.

I found the problem when compilng with DEBUG macro. The above memset overwrote FILE *debugfh with zero.