### PR TITLE
Check return value of fopen() to avoid segmentation fault (DEBUG).

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -110,7 +110,12 @@
 #undef DEBUG
 #ifdef DEBUG
 FILE *debugfh;
-#define DEBUGOPEN(file)		do { debugfh = fopen(file, "w"); } while (0)
+#define DEBUGOPEN(file)							\
+	do {								\
+		debugfh = fopen(file, "w");				\
+		if (debugfh == NULL)					\
+			err(2, "Failed to open %s", file);		\
+	} while (0)
 #define DEBUGLOG(fmt, args...)	do { fprintf(debugfh, fmt, ## args); fflush(debugfh); } while (0)
 #define DEBUGCLOSE()		fclose(debugfh)
 #else


### PR DESCRIPTION
 Fix a problem that DEBUGLOG() causes segmentation fault if fopen() failed.
2 is used for the error code. It might be good to rethink the value in future.