### PR TITLE
Make it possible to use DEBUGLOG() other than gen.c

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -107,21 +107,8 @@
 #define	PORT_DEFAULT		9	/* discard port */
 #define MAXFLOWNUM		(1024 * 1024)
 
-#undef DEBUG
 #ifdef DEBUG
 FILE *debugfh;
-#define DEBUGOPEN(file)							\
-	do {								\
-		debugfh = fopen(file, "w");				\
-		if (debugfh == NULL)					\
-			err(2, "Failed to open %s", file);		\
-	} while (0)
-#define DEBUGLOG(fmt, args...)	do { fprintf(debugfh, fmt, ## args); fflush(debugfh); } while (0)
-#define DEBUGCLOSE()		fclose(debugfh)
-#else
-#define DEBUGOPEN(file)		((void)0)
-#define DEBUGLOG(args...)	((void)0)
-#define DEBUGCLOSE()		((void)0)
 #endif
 
 #define printf_verbose(fmt, args...)	do { if (verbose > 0) printf(fmt, ## args);} while (0)

--- a/gen/gen.h
+++ b/gen/gen.h
@@ -97,4 +97,20 @@ int statistics_clear(void);
 
 extern struct timespec currenttime;
 
+#ifdef DEBUG
+extern FILE *debugfh;
+#define DEBUGOPEN(file)							\
+	do {								\
+		debugfh = fopen(file, "w");				\
+		if (debugfh == NULL)					\
+			err(2, "Failed to open %s", file);		\
+	} while (0)
+#define DEBUGLOG(fmt, args...)	do { fprintf(debugfh, fmt, ## args); fflush(debugfh); } while (0)
+#define DEBUGCLOSE()		fclose(debugfh)
+#else
+#define DEBUGOPEN(file)		((void)0)
+#define DEBUGLOG(args...)	((void)0)
+#define DEBUGCLOSE()		((void)0)
+#endif
+
 #endif /* _GEN_H_ */


### PR DESCRIPTION
Move DEBUG*() macros from gen.c to gen.h.
The intention is to use DEBUGLOG() other than gen.c
It also remove "undef DEBUG" to pass DEBUG macro via cc(1) command.
Tested on FreeBSD and Ubuntu 23.10