### PR TITLE
Make sequencecheck.c possible to use DEBUGLOG() in it.

### DIFF
--- a/gen/sequencecheck.c
+++ b/gen/sequencecheck.c
@@ -28,10 +28,17 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
+#include "gen.h"
 #include "sequencecheck.h"
 
 #if defined(__FreeBSD__) && defined(__x86_64__)
 #include <machine/cpufunc.h>
+#endif
+
+#if defined(DEBUG) && defined(TEST)
+#undef DEBUGLOG
+#define DEBUGLOG(fmt, args...)	printf(fmt, ## args)
 #endif
 
 struct sequencechecker {


### PR DESCRIPTION
 Use #ifdef TEST instead of #if 0 to make it possible to compile
sequencecheck.c as standalone (i.e. cc -D TEST).

 If sequencechec.c is compiled with TEST, DEBUGLOG() prints
it's log message to the stdout. If TEST is not set, the behavior
is the same as usual(log to ipgen-debug.log).