### PR TITLE
Wait all threads before closing netmap interfaces to avoid segmentation fault

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -1299,6 +1299,9 @@ interface_open(int ifno)
 	iface->opened = 1;
 }
 
+/*
+ * This function should be called after finishing TX/TX threads.
+ */
 void
 interface_close(int ifno)
 {
@@ -1309,34 +1312,7 @@ interface_close(int ifno)
 		interface_promisc(iface->ifname, iface->promisc_save, NULL);
 
 #ifdef USE_NETMAP
-#if 0	/* XXX */
-	/*
-	 * XXX: freebsd bug? closing netmap file descriptor sometimes cause panic
-	 *
-	 * panic: Bad link elm 0xffff0017e7df500 prev->next != elm
-	 * cpuid = 3
-	 * KDB: stack backtrace:
-	 * db_trace_self_wrapper()
-	 * vpanic()
-	 * panic()
-	 * selfdfree()
-	 * kern_poll()
-	 * sys_poll()
-	 * amd64_syscall()
-	 * Xfast_syscall()
-	 *
-	 */
 	nm_close(iface->nm_desc);
-#else
-
-	/*
-	 * timeout of poll() in rx_thread_main() is 100ms,
-	 * sleeping 200ms to wait returning from poll().
-	 */
-	usleep(200000);
-	nm_close(iface->nm_desc);
-#endif
-
 #elif defined(USE_AF_XDP)
 	/*
 	 * timeout of poll() in rx_thread_main() is 100ms,

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2209,7 +2209,14 @@ quit(int fromsig)
 	printf("Exiting...\n");
 	fflush(stdout);
 
-
+	if (!opt_txonly) {
+		pthread_join(txthread0, NULL);
+		pthread_join(rxthread0, NULL);
+	}
+	if (!opt_rxonly) {
+		pthread_join(txthread1, NULL);
+		pthread_join(rxthread1, NULL);
+	}
 	interface_close(0);
 	interface_close(1);
 


### PR DESCRIPTION
This problem occurred when 'q' is pressed while running RFC2544 test.

e.g.
(press 'q')
Exiting...
Segmentation fault (core dumped)
(gdb)
Program terminated with signal SIGSEGV, Segmentation fault.
Address not mapped to object.
#0  0x0000000000214495 in nm_ring_next (r=0x825a4f000, i=153) at ./netmap_user_localdebug.h:102
102             return ( unlikely(i + 1 == r->num_slots) ? 0 : i + 1);
[Current thread is 1 (LWP 100923)]
(gdb) where
#0  0x0000000000214495 in nm_ring_next (r=0x825a4f000, i=153) at ./netmap_user_localdebug.h:102
#1  0x0000000000214bcd in interface_receive (ifno=0) at gen.c:1814
#2  0x00000000002118ec in rx_thread_main (arg=0x82069a958) at gen.c:2470
#3  0x00000008227d9a75 in thread_start (curthread=0x1f23dcc12e00)
    at /usr/src/lib/libthr/thread/thr_create.c:290
#4  0x0000000000000000 in ?? ()

It seems interface_close() is called before stopping threads.
Calling pthread_join() before closing netmap interfaces solve the problem.