### PR TITLE
Prepend timestamp in DEBUGLOG().

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2315,20 +2315,6 @@ usage(void)
 	exit(1);
 }
 
-char *
-timestamp(time_t t)
-{
-	static char tstamp[128];
-	time_t mytime;
-	struct tm ltime;
-
-	mytime = t;
-	localtime_r(&mytime, &ltime);
-	strftime(tstamp, sizeof(tstamp), "%F %T", &ltime);
-
-	return tstamp;
-}
-
 static void
 logging(char const *fmt, ...)
 {

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2315,8 +2315,7 @@ usage(void)
 	exit(1);
 }
 
-
-static char *
+char *
 timestamp(time_t t)
 {
 	static char tstamp[128];

--- a/gen/gen.h
+++ b/gen/gen.h
@@ -94,10 +94,12 @@ unsigned int getpktsize(int);
 int setpktsize(int, unsigned int);
 void transmit_set(int, int);
 int statistics_clear(void);
+char *timestamp(time_t);
 
 extern struct timespec currenttime;
 
 #ifdef DEBUG
+#include <time.h>
 extern FILE *debugfh;
 #define DEBUGOPEN(file)							\
 	do {								\
@@ -105,7 +107,23 @@ extern FILE *debugfh;
 		if (debugfh == NULL)					\
 			err(2, "Failed to open %s", file);		\
 	} while (0)
-#define DEBUGLOG(fmt, args...)	do { fprintf(debugfh, fmt, ## args); fflush(debugfh); } while (0)
+/* Log to ipgen-debug.log with timestamp. */
+#define DEBUGLOG(fmt, args...)						 \
+	do {								 \
+		struct timespec realtime_now;				 \
+									 \
+		clock_gettime(CLOCK_REALTIME, &realtime_now);		 \
+		fprintf(debugfh, "%s ", timestamp(realtime_now.tv_sec)); \
+		fprintf(debugfh, fmt, ## args); fflush(debugfh);	 \
+	} while (0)
+/*
+ * Log to ipgen-debug.log without timestamp.
+ * Used to write multiple debuglog as one line.
+ */
+#define DEBUGLOG_CONT(fmt, args...)					\
+	do {								\
+		fprintf(debugfh, fmt, ## args); fflush(debugfh);	\
+	} while (0)
 #define DEBUGCLOSE()		fclose(debugfh)
 #else
 #define DEBUGOPEN(file)		((void)0)

--- a/gen/gen.h
+++ b/gen/gen.h
@@ -94,12 +94,10 @@ unsigned int getpktsize(int);
 int setpktsize(int, unsigned int);
 void transmit_set(int, int);
 int statistics_clear(void);
-char *timestamp(time_t);
 
 extern struct timespec currenttime;
 
 #ifdef DEBUG
-#include <time.h>
 extern FILE *debugfh;
 #define DEBUGOPEN(file)							\
 	do {								\

--- a/gen/sequencecheck.c
+++ b/gen/sequencecheck.c
@@ -38,7 +38,9 @@
 
 #if defined(DEBUG) && defined(TEST)
 #undef DEBUGLOG
+#undef DEBUGLOG_CONT
 #define DEBUGLOG(fmt, args...)	printf(fmt, ## args)
+#define DEBUGLOG_CONT(fmt, args...) printf(fmt, ## args)
 #endif
 
 struct sequencechecker {

--- a/gen/util.c
+++ b/gen/util.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <err.h>
 #include <errno.h>
+#include <time.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <net/if.h>
@@ -204,6 +205,20 @@ getword(char *str, char sep, char **save, char *buf, size_t bufsize)
 			*d++ = c;
 	}
 	return buf;
+}
+
+char *
+timestamp(time_t t)
+{
+	static char tstamp[128];
+	time_t mytime;
+	struct tm ltime;
+
+	mytime = t;
+	localtime_r(&mytime, &ltime);
+	strftime(tstamp, sizeof(tstamp), "%F %T", &ltime);
+
+	return tstamp;
 }
 
 int

--- a/gen/util.h
+++ b/gen/util.h
@@ -36,6 +36,7 @@
 
 void chop(char *);
 char *getword(char *str, char sep, char **save, char *buf, size_t bufsize);
+char *timestamp(time_t);
 int interface_is_active(const char *);
 struct in_addr *getifipaddr(const char *, struct in_addr *, struct in_addr *);
 struct in6_addr *getifip6addr(const char *, struct in6_addr *, struct in6_addr *);


### PR DESCRIPTION
 Prepend timestamp when DEBUGLOG() is used.
DEBUGLOG_CONT() doesn't prepend timestamp, so you can use DEBUGLOG("string without newline"); DEBUGLOG_CONT("string..\n") to write in one line.