### PR TITLE
Add missing printf format string to reduce warning.

### DIFF
--- a/gen/item.c
+++ b/gen/item.c
@@ -538,9 +538,9 @@ itemlist_update(struct itemlist *itemlist, int force)
 	if (!itemlist->ready) {
 		itemlist->ready = 1;
 		CLEAR();
-		PRINTF(itemlist->template);
+		PRINTF("%s", itemlist->template);
 	} else if (force)
-		PRINTF(itemlist->template);
+		PRINTF("%s", itemlist->template);
 
 
 #ifdef ITEM_DEBUG


### PR DESCRIPTION
This problem was found on Ubuntu.

item.c:541:10: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
                PRINTF(itemlist->template);
                       ^~~~~~~~~~~~~~~~~~
item.c:49:40: note: expanded from macro 'PRINTF'
#define PRINTF(format, args...) printw(format, ## args)
                                       ^~~~~~
item.c:541:10: note: treat the string as an argument to avoid this
                PRINTF(itemlist->template);
                       ^
                       "%s",
item.c:49:40: note: expanded from macro 'PRINTF'
#define PRINTF(format, args...) printw(format, ## args)
                                       ^

The reason why the warning is not shown on FreeBSD is that the prototype definition of printw() is not __printflike'd in /usr/inlclude/curses.h.