### PR TITLE
Style. No functional change

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -111,7 +111,11 @@
 FILE *debugfh;
 #endif
 
-#define printf_verbose(fmt, args...)	do { if (verbose > 0) printf(fmt, ## args);} while (0)
+#define printf_verbose(fmt, args...)		\
+	do {					\
+		if (verbose > 0)		\
+			printf(fmt, ## args);	\
+	} while (0)
 
 
 static void logging(char const *fmt, ...) __printflike(1, 2);
@@ -795,13 +799,15 @@ reset_ipg(int ifno)
 	const char *drvname = iface->drvname;
 
 #ifdef __linux__
-#define BUILD_CMD(target, value)	snprintf(buf, sizeof(buf), \
-					    "echo %d > /sys/class/net/%s/%s", \
-					    value, iface->ifname, target);
+#define BUILD_CMD(target, value)				\
+	snprintf(buf, sizeof(buf),				\
+	    "echo %d > /sys/class/net/%s/%s",			\
+	    value, iface->ifname, target);
 #else
-#define BUILD_CMD(target, value)	snprintf(buf, sizeof(buf), \
-					    "sysctl -q -w dev.%s.%lu.%s=%d > /dev/null", \
-					    drvname, iface->unit, target, value);
+#define BUILD_CMD(target, value)				\
+	snprintf(buf, sizeof(buf),				\
+	    "sysctl -q -w dev.%s.%lu.%s=%d > /dev/null",	\
+	    drvname, iface->unit, target, value);
 #endif
 
 	if (!support_ipg)

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -631,7 +631,7 @@ touchup_tx_packet(char *buf, int ifno)
 		seqrecord->flowseq = iface->sequence_tx_perflow[flowid]++;
 		seqrecord->ts = currenttime_tx;
 
-		if (ipv6) 
+		if (ipv6)
 			ip6pkt_writedata(buf, l3offset, l4payloadsize - sizeof(seqdata), (char *)&seqdata, sizeof(seqdata));
 		else
 			ip4pkt_writedata(buf, l3offset, l4payloadsize - sizeof(seqdata), (char *)&seqdata, sizeof(seqdata));
@@ -980,7 +980,7 @@ calc_ipg(int ifno)
 			return;
 		}
 
-		/* 82599 and newer */ 
+		/* 82599 and newer */
 		if (iface->transmit_pps == 0) {
 			bps = 0;
 		} else {

--- a/gen/genscript.c
+++ b/gen/genscript.c
@@ -176,13 +176,13 @@ genscript_read(struct genscript *genscript, const char *path)
 		if ((q = strcasestr(wbuf, "gbps")) != NULL && strlen(q) == 4) {
 			bps = strtoull(wbuf, NULL, 10);
 			pps = bps * 1000000000ULL / 8 / PKTSIZE2FRAMESIZE(pktsize + 14);
-		} else if  ((q = strcasestr(wbuf, "mbps")) != NULL && strlen(q) == 4) {
+		} else if ((q = strcasestr(wbuf, "mbps")) != NULL && strlen(q) == 4) {
 			bps = strtoull(wbuf, NULL, 10);
 			pps = bps * 1000000ULL / 8 / PKTSIZE2FRAMESIZE(pktsize + 14);
-		} else if  ((q = strcasestr(wbuf, "kbps")) != NULL && strlen(q) == 4) {
+		} else if ((q = strcasestr(wbuf, "kbps")) != NULL && strlen(q) == 4) {
 			bps = strtoull(wbuf, NULL, 10);
 			pps = bps * 1000ULL / 8 / PKTSIZE2FRAMESIZE(pktsize + 14);
-		} else if  ((q = strcasestr(wbuf, "bps")) != NULL && strlen(q) == 3) {
+		} else if ((q = strcasestr(wbuf, "bps")) != NULL && strlen(q) == 3) {
 			bps = strtoull(wbuf, NULL, 10);
 			pps = bps / 8ULL / PKTSIZE2FRAMESIZE(pktsize + 14);
 		} else {

--- a/gen/item.c
+++ b/gen/item.c
@@ -38,13 +38,13 @@
 /* XXX: use termcap/terminfo */
 #ifdef ITEM_DEBUG
 #define	CLEAR()		(void)0
-#define	LOCATE(x,y)	(void)0
+#define	LOCATE(x, y)	(void)0
 #define	REFRESH()	(void)0
 #define	PRINTF(format, args...)	printf(format, ## args)
 #define	BEEP()		(void)0
 #else
 #define	CLEAR()		clear()
-#define	LOCATE(x,y)	move(y,x)
+#define	LOCATE(x, y)	move(y, x)
 #define	REFRESH()	refresh()
 #define	PRINTF(format, args...)	printw(format, ## args)
 #define	BEEP()		beep()

--- a/gen/webserv.c
+++ b/gen/webserv.c
@@ -96,7 +96,7 @@ handler_index(struct webserv *web, const char *path, int argc, char *argv[])
 		fh = fopen(buf, "r");
 
 		if (fh != NULL) {
-			fprintf(web->fh, 
+			fprintf(web->fh,
 			    "HTTP/1.0 200 Found\r\n"
 			    "Content-Type: text/html\r\n"
 			    "\r\n");
@@ -111,7 +111,7 @@ handler_index(struct webserv *web, const char *path, int argc, char *argv[])
 		}
 
 	} else if (argc == 0) {
-		fprintf(web->fh, 
+		fprintf(web->fh,
 		    "HTTP/1.0 200 Found\r\n"
 		    "Content-Type: text/html\r\n"
 		    "\r\n"

--- a/libpkt/ip6pkt.c
+++ b/libpkt/ip6pkt.c
@@ -185,7 +185,7 @@ ip6pkt_neighbor_solicit_reply(char *buf, const char *solicitbuf, u_char *eaddr, 
 
 	ndpkt_l2->ip6.ip6_dst = ondpkt_l3->ip6.ip6_src;
 	ndpkt_l2->nd_icmp6.icmp6_type = ND_NEIGHBOR_ADVERT;
-	ndpkt_l2->nd_icmp6.icmp6_data32[0] = 
+	ndpkt_l2->nd_icmp6.icmp6_data32[0] =
 	    ND_NA_FLAG_SOLICITED |
 	    ND_NA_FLAG_OVERRIDE;
 
@@ -480,7 +480,7 @@ ip6pkt_srcdst(int srcdst, char *buf, unsigned int l3offset, const struct in6_add
 		ip6->ip6_src = *addr;
 	} else {
 		old = ip6->ip6_dst;
-		ip6->ip6_dst= *addr;
+		ip6->ip6_dst = *addr;
 	}
 
 #ifndef s6_addr16

--- a/libpkt/ip6pkt.c
+++ b/libpkt/ip6pkt.c
@@ -85,7 +85,7 @@ static int ip6pkt_icmp_uint16(char *, unsigned int, int, uint16_t);
 int
 ip6pkt_neighbor_solicit(char *buf, const struct ether_addr *sha, struct in6_addr *addr1, struct in6_addr *addr2)
 {
-	u_int8_t edst[ETHER_ADDR_LEN] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };	/* XXX: should to use multicast address */
+	uint8_t edst[ETHER_ADDR_LEN] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };	/* XXX: should to use multicast address */
 	struct ndpkt_l2 *ndpkt;
 	unsigned int ip6len, protolen;
 	int len;

--- a/libpkt/test.c
+++ b/libpkt/test.c
@@ -41,7 +41,7 @@ main(int argc, char *argv[])
 	char buf[1514];
 	int len, fd;
 
-	const struct ether_addr sha = { 1,2,3,4,5,6};
+	const struct ether_addr sha = { 1,2,3,4,5,6 };
 	in_addr_t s, t;
 
 	fd = tcpdumpfile_open(NULL);


### PR DESCRIPTION
- Fold long macros for readability.
- Modify extra whitespaces.
- Fold long prototypes in function definitions.
- s/u_int8_t/uint8_t/ for consistency.
