### PR TITLE
Don't warn if the baudrate is higher than 10Gbps.

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -4319,14 +4319,6 @@ main(int argc, char *argv[])
 					fprintf(stderr,
 					    "%s: WARINIG: baudrate(%lu) < IF_Mbps(10)\n",
 					    ifname[i], linkspeed);
-				} else if (linkspeed > IF_Gbps(10)) {
-					/*
-					 * If the baudrate is higher than 10Gbps,
-					 * something is wrong.
-					 */
-					fprintf(stderr,
-					    "%s: WARINIG: baudrate(%lu) > IF_Gbps(10)\n",
-					    ifname[i], linkspeed);
 				} else {
 					interface[i].maxlinkspeed = linkspeed;
 					printf_verbose("%s: linkspeed = %lu\n", ifname[i], linkspeed);


### PR DESCRIPTION
It's not required to warn higher than 10Gbps baudrate because we support 25G, 40G and 100G interfaces.