### PR TITLE
Fix compile error/warning of sequencecheck.c with DEBUG+DEBUGLOG().

### DIFF
--- a/gen/gen.h
+++ b/gen/gen.h
@@ -57,6 +57,8 @@
 #ifndef _GEN_H_
 #define _GEN_H_
 
+#include <time.h>
+
 #ifndef timespeccmp
 #define	timespeccmp(tvp, uvp, cmp)					\
 	(((tvp)->tv_sec == (uvp)->tv_sec) ?				\

--- a/gen/sequencecheck.c
+++ b/gen/sequencecheck.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "gen.h"
+#include "util.h"
 #include "sequencecheck.h"
 
 #if defined(__FreeBSD__) && defined(__x86_64__)

--- a/gen/util.h
+++ b/gen/util.h
@@ -33,6 +33,7 @@
 #endif
 #include <ifaddrs.h>
 #include <net/ethernet.h>
+#include <netinet/in.h>
 
 void chop(char *);
 char *getword(char *str, char sep, char **save, char *buf, size_t bufsize);


### PR DESCRIPTION
Tested on both FreeBSD and Linux.

sequencecheck.c
	Include "util.h" for timestamp().

util.h
	Include <netinet/in.h> for in_addr_t (at least Linux requires it).

gen.h
	Include <time.h> for clock_gettime() (at least Linux requires it).