### PR TITLE
Add -Wextra to gen/GNUmakefile

### DIFF
--- a/gen/GNUmakefile
+++ b/gen/GNUmakefile
@@ -6,6 +6,7 @@ CFLAGS+=	-I.. -I/usr/local/include -g -DHTDOCS=\"${PREFIX}/share/ipgen/htdocs\"
 CFLAGS+=	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith
 CFLAGS+=	-Wreturn-type -Wswitch # -Wshadow XXX for gen.c
 CFLAGS+=	-Wcast-qual -Wwrite-strings
+CFLAGS+=	-Wextra
 LDADD=		-L../libpkt -lpkt -L../libaddrlist -L/usr/local/lib -laddrlist -lpthread -lc -lcurses -levent -lmd
 
 ifeq ($(shell uname),Linux)

--- a/gen/af_xdp.c
+++ b/gen/af_xdp.c
@@ -154,7 +154,7 @@ ax_wait_for_packets(struct ax_desc *ax_desc, struct ax_rx_handle *handle)
 {
 	struct ax_socket *axs = ax_desc->axs;
 	unsigned int npkts;
-	int ret;
+	unsigned int ret;
 
 	npkts = xsk_ring_cons__peek(&axs->rring, BATCH_SIZE, &handle->rring_idx);
 	if (npkts == 0) {

--- a/gen/arpresolv.c
+++ b/gen/arpresolv.c
@@ -97,6 +97,12 @@ static int getifinfo(const char *, int *, uint8_t *);
 		}							\
 	} while (/* CONSTCOND */ 0)
 
+#ifdef STANDALONE_TEST
+#define	__testused
+#else
+#define	__testused	__unused
+#endif
+
 struct recvarp_arg {
 	struct in_addr src;
 	struct ether_addr src_eaddr;
@@ -337,7 +343,7 @@ main(int argc, char *argv[])
 #endif
 
 static int
-recv_arpreply(void *arg, unsigned char *buf, int buflen, const char *ifname)
+recv_arpreply(void *arg, unsigned char *buf, int buflen, const char *ifname __testused)
 {
 	struct arppkt_l2 *arppkt;
 	struct recvarp_arg *recvarparg;
@@ -364,7 +370,7 @@ recv_arpreply(void *arg, unsigned char *buf, int buflen, const char *ifname)
 }
 
 static int
-recv_nd(void *arg, unsigned char *buf, int buflen, const char *ifname)
+recv_nd(void *arg, unsigned char *buf, int buflen, const char *ifname __testused)
 {
 	struct ndpkt_l2 *ndpkt_l2;
 	struct recvnd_arg *recvndarg;
@@ -769,7 +775,7 @@ vlanize_malloc(int vlan, const char *pkt, unsigned int pktsize)
 }
 
 static void
-arpquery(int fd, const char *ifname, struct ether_addr *sha, int vlan, struct in_addr *src, struct in_addr *dst)
+arpquery(int fd, const char *ifname __testused, struct ether_addr *sha, int vlan, struct in_addr *src, struct in_addr *dst)
 {
 	struct arppkt_l2 aquery;
 	static const uint8_t eth_broadcast[ETHER_ADDR_LEN] =
@@ -808,7 +814,7 @@ arpquery(int fd, const char *ifname, struct ether_addr *sha, int vlan, struct in
 }
 
 static void
-ndsolicit(int fd, const char *ifname, struct ether_addr *sha, int vlan, struct in6_addr *src, struct in6_addr *dst)
+ndsolicit(int fd, const char *ifname __testused, struct ether_addr *sha, int vlan, struct in6_addr *src, struct in6_addr *dst)
 {
 	char pktbuf[LIBPKT_PKTBUFSIZE];
 	unsigned int pktlen;

--- a/gen/arpresolv_linux.c
+++ b/gen/arpresolv_linux.c
@@ -62,6 +62,7 @@
 
 #include "libpkt/libpkt.h"
 #include "arpresolv.h"
+#include "compat.h"
 
 
 static int afpkt_read_and_exec(int (*)(void *, unsigned char *, int, const char *), void *, int, const char *, unsigned char *, int);
@@ -87,6 +88,12 @@ struct recvnd_arg {
 #define BUFSIZE	(1024 * 4)
 static unsigned char buf[BUFSIZE];
 static unsigned int buflen = BUFSIZE;
+
+#ifdef DEBUG
+#define __debugused
+#else
+#define __debugused	__unused
+#endif
 
 #ifdef DEBUG
 static int
@@ -234,7 +241,7 @@ main(int argc, char *argv[])
 #endif
 
 static int
-recv_arpreply(void *arg, unsigned char *buf, int buflen, const char *ifname)
+recv_arpreply(void *arg, unsigned char *buf, int buflen, const char *ifname __debugused)
 {
 	struct ether_arp *arp;
 	struct recvarp_arg *recvarparg;
@@ -256,7 +263,7 @@ recv_arpreply(void *arg, unsigned char *buf, int buflen, const char *ifname)
 }
 
 static int
-recv_nd(void *arg, unsigned char *buf, int buflen, const char *ifname)
+recv_nd(void *arg, unsigned char *buf, int buflen, const char *ifname __debugused)
 {
 	struct recvnd_arg *recvndarg;
 	struct icmp6_hdr *icmp6;
@@ -447,7 +454,7 @@ close_exit:
 }
 
 static int
-afpkt_open(const char *ifname, int promisc, unsigned int *buflen, int proto)
+afpkt_open(const char *ifname, int promisc __unused, unsigned int *buflen, int proto)
 {
 	int fd, rc;
 	struct sockaddr_ll sall;
@@ -471,7 +478,7 @@ afpkt_open(const char *ifname, int promisc, unsigned int *buflen, int proto)
 }
 
 static int
-afpkt_open_raw(const char *ifname, int promisc, unsigned int *buflen)
+afpkt_open_raw(const char *ifname, int promisc __unused, unsigned int *buflen)
 {
 	int fd, rc;
 	struct sockaddr_ll sall;

--- a/gen/compat.h
+++ b/gen/compat.h
@@ -69,4 +69,8 @@ atomic_cmpset_32(volatile uint32_t *p, uint32_t cmpval, uint32_t newval)
 }
 #endif
 
+#ifndef __unused
+#define __unused	__attribute__((unused))
+#endif
+
 #endif /* _COMPAT_H_ */

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2552,8 +2552,8 @@ struct rfc2544_work {
 
 #define RFC2544_MAXTESTNUM	64
 struct rfc2544_work rfc2544_work[RFC2544_MAXTESTNUM];
-static int rfc2544_ntest = 0;
-static int rfc2544_nthtest = 0;
+static u_int rfc2544_ntest = 0;
+static u_int rfc2544_nthtest = 0;
 
 typedef enum {
 	RFC2544_START,
@@ -2609,7 +2609,7 @@ rfc2544_load_default_test(uint64_t maxlinkspeed)
 static void
 rfc2544_calc_param(uint64_t maxlinkspeed)
 {
-	int i;
+	u_int i;
 
 	for (i = 0; i < rfc2544_ntest; i++) {
 		rfc2544_work[i].maxpps = maxlinkspeed / 8 / (rfc2544_work[i].pktsize + 18 + DEFAULT_IFG + DEFAULT_PREAMBLE);
@@ -2621,7 +2621,7 @@ rfc2544_showresult(void)
 {
 	double mbps, tmp;
 	unsigned int pps, linkspeed;
-	int i, j;
+	u_int i, j;
 
 	/*
 	 * [example]
@@ -2767,7 +2767,7 @@ void
 rfc2544_showresult_json(char *filename)
 {
 	double bps;
-	int i;
+	u_int i;
 	FILE *fp;
 
 	/*

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -128,7 +128,7 @@ char ipgen_version[] = "1.29";
 #define DISPLAY_UPDATE_HZ	20
 #define DEFAULT_PPS_HZ		1000
 u_int pps_hz = DEFAULT_PPS_HZ;
-int opt_npkt_sync = 0x7fffffff;
+u_int opt_npkt_sync = 0x7fffffff;
 u_int opt_nflow = 0;
 
 bool use_curses = true;

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -3223,7 +3223,7 @@ control_interval(struct itemlist *itemlist)
 }
 
 static int
-itemlist_callback_burst_steady(struct itemlist *itemlist, struct item *item, void *refptr __unused)
+itemlist_callback_burst_steady(struct itemlist *itemlist __unused, struct item *item, void *refptr __unused)
 {
 	switch (item->id) {
 	case ITEMLIST_ID_BUTTON_BURST:
@@ -3264,7 +3264,7 @@ itemlist_callback_l1_l2(struct itemlist *itemlist, struct item *item, void *refp
 }
 
 static int
-itemlist_callback_nflow(struct itemlist *itemlist, struct item *item, void *refptr)
+itemlist_callback_nflow(struct itemlist *itemlist __unused, struct item *item __unused, void *refptr)
 {
 	int *nflow_test;
 
@@ -3279,7 +3279,7 @@ itemlist_callback_nflow(struct itemlist *itemlist, struct item *item, void *refp
 }
 
 static int
-itemlist_callback_pktsize(struct itemlist *itemlist, struct item *item, void *refptr)
+itemlist_callback_pktsize(struct itemlist *itemlist __unused, struct item *item, void *refptr)
 {
 	uint32_t *pktsize;
 	int ifno;
@@ -3307,7 +3307,7 @@ itemlist_callback_pktsize(struct itemlist *itemlist, struct item *item, void *re
 }
 
 static int
-itemlist_callback_pps(struct itemlist *itemlist, struct item *item, void *refptr)
+itemlist_callback_pps(struct itemlist *itemlist __unused, struct item *item, void *refptr)
 {
 	uint32_t *pps;
 	int ifno;
@@ -3331,7 +3331,7 @@ itemlist_callback_pps(struct itemlist *itemlist, struct item *item, void *refptr
 }
 
 static int
-itemlist_callback_startstop(struct itemlist *itemlist, struct item *item, void *refptr __unused)
+itemlist_callback_startstop(struct itemlist *itemlist __unused, struct item *item, void *refptr __unused)
 {
 	switch (item->id) {
 	case ITEMLIST_ID_IF0_START:

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -127,7 +127,7 @@ char ipgen_version[] = "1.29";
 
 #define DISPLAY_UPDATE_HZ	20
 #define DEFAULT_PPS_HZ		1000
-int pps_hz = DEFAULT_PPS_HZ;
+u_int pps_hz = DEFAULT_PPS_HZ;
 int opt_npkt_sync = 0x7fffffff;
 u_int opt_nflow = 0;
 

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -3499,7 +3499,7 @@ control_init_items(struct itemlist *itemlist)
 
 
 static void
-evt_accept_callback(evutil_socket_t fd, short event, void *arg)
+evt_accept_callback(evutil_socket_t fd, short event __unused, void *arg __unused)
 {
 	struct sockaddr_in sin;
 	socklen_t sinlen = sizeof(sin);
@@ -3515,7 +3515,7 @@ evt_accept_callback(evutil_socket_t fd, short event, void *arg)
 }
 
 static void
-evt_readable_stdin_callback(evutil_socket_t fd, short event, void *arg)
+evt_readable_stdin_callback(evutil_socket_t fd, short event __unused, void *arg)
 {
 	struct itemlist *itemlist;
 
@@ -3524,7 +3524,7 @@ evt_readable_stdin_callback(evutil_socket_t fd, short event, void *arg)
 }
 
 static void
-evt_timeout_callback(evutil_socket_t fd, short event, void *arg)
+evt_timeout_callback(evutil_socket_t fd __unused, short event __unused, void *arg)
 {
 	struct itemlist *itemlist;
 

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2423,7 +2423,7 @@ rx_thread_main(void *arg)
 static void
 genscript_play(int unsigned n)
 {
-	static int nth_test = -1;
+	static u_int nth_test = 0;
 	static int period_left = 0;
 	struct genscript_item *genitem;
 
@@ -2433,8 +2433,8 @@ genscript_play(int unsigned n)
 	period_left--;
 	if (period_left <= 0) {
 		do {
-			nth_test++;
 			genitem = genscript_get_item(genscript, nth_test);
+			nth_test++;
 			if (genitem == NULL) {
 				quit(false);
 				return;

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -3539,7 +3539,7 @@ evt_timeout_callback(evutil_socket_t fd __unused, short event __unused, void *ar
 
 
 static void *
-control_thread_main(void *arg)
+control_thread_main(void *arg __unused)
 {
 	struct event ev_tty;
 	struct event ev_timer;

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -3223,7 +3223,7 @@ control_interval(struct itemlist *itemlist)
 }
 
 static int
-itemlist_callback_burst_steady(struct itemlist *itemlist, struct item *item, void *refptr)
+itemlist_callback_burst_steady(struct itemlist *itemlist, struct item *item, void *refptr __unused)
 {
 	switch (item->id) {
 	case ITEMLIST_ID_BUTTON_BURST:
@@ -3239,7 +3239,7 @@ itemlist_callback_burst_steady(struct itemlist *itemlist, struct item *item, voi
 }
 
 static int
-itemlist_callback_l1_l2(struct itemlist *itemlist, struct item *item, void *refptr)
+itemlist_callback_l1_l2(struct itemlist *itemlist, struct item *item, void *refptr __unused)
 {
 	switch (item->id) {
 	case ITEMLIST_ID_BUTTON_BPS_L1:
@@ -3331,7 +3331,7 @@ itemlist_callback_pps(struct itemlist *itemlist, struct item *item, void *refptr
 }
 
 static int
-itemlist_callback_startstop(struct itemlist *itemlist, struct item *item, void *refptr)
+itemlist_callback_startstop(struct itemlist *itemlist, struct item *item, void *refptr __unused)
 {
 	switch (item->id) {
 	case ITEMLIST_ID_IF0_START:

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -190,7 +190,7 @@ int opt_flowsort = 0;
 int opt_flowdump = 0;
 char *opt_flowlist = NULL;
 
-int min_pktsize = 46;	/* not include ether-header. udp4:46, tcp4:46, udp6:54, tcp6:66 */
+u_int min_pktsize = 46;	/* not include ether-header. udp4:46, tcp4:46, udp6:54, tcp6:66 */
 
 int force_redraw_screen = 0;
 int do_quit = 0;

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -2043,7 +2043,7 @@ broadcast_json_statistics(char *buf, unsigned int len)
 }
 
 static void
-sighandler_alrm(int signo)
+sighandler_alrm(int signo __unused)
 {
 	static uint32_t _nhz = 0;
 	uint32_t nhz;
@@ -2222,13 +2222,13 @@ quit(int fromsig)
 }
 
 static void
-sighandler_int(int signo)
+sighandler_int(int signo __unused)
 {
 	quit(true);
 }
 
 static void
-sighandler_tstp(int signo)
+sighandler_tstp(int signo __unused)
 {
 	itemlist_fini_term();
 
@@ -2240,7 +2240,7 @@ sighandler_tstp(int signo)
 }
 
 static void
-sighandler_cont(int signo)
+sighandler_cont(int signo __unused)
 {
 	signal(SIGTSTP, sighandler_tstp);
 }

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -129,7 +129,7 @@ char ipgen_version[] = "1.29";
 #define DEFAULT_PPS_HZ		1000
 int pps_hz = DEFAULT_PPS_HZ;
 int opt_npkt_sync = 0x7fffffff;
-int opt_nflow = 0;
+u_int opt_nflow = 0;
 
 bool use_curses = true;
 
@@ -472,7 +472,7 @@ in_range(int num, int begin, int end)
 	return 1;
 }
 
-static inline int
+static inline u_int
 get_flowid_max(int ifno)
 {
 	return addresslist_get_tuplenum(interface[ifno].adrlist) - 1;

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -698,12 +698,13 @@ getdrvname(const char *ifname, char *drvname)
 static int
 getifunit(const char *ifname, char *drvname, unsigned long *unit)
 {
-	int i;
+	u_int i;
 
-	for (i = strlen(ifname) - 1; i >= 0; i--)
+	for (i = strlen(ifname) - 1; i > 0; i--)
 		if (!isdigit(*(ifname + i)))
 			break;
-	if ((i < 0) || (i == strlen(ifname) - 1))
+	if (((i == 0) && isdigit(ifname[0])) || /* All characters are digit */
+	    (i == strlen(ifname) - 1)) /* The last character is not digit */
 		return -1;
 
 	i++;

--- a/gen/genscript.c
+++ b/gen/genscript.c
@@ -68,7 +68,7 @@ genscript_add_item(struct genscript *genscript, unsigned int cmd, unsigned int p
 }
 
 struct genscript_item *
-genscript_get_item(struct genscript *genscript, int idx)
+genscript_get_item(struct genscript *genscript, u_int idx)
 {
 	if (idx < 0 || idx >= genscript->nitems)
 		return NULL;

--- a/gen/genscript.h
+++ b/gen/genscript.h
@@ -55,7 +55,7 @@ genscript_cmdname(unsigned int cmd)
 
 struct genscript *genscript_new(const char *);
 void genscript_delete(struct genscript *);
-struct genscript_item *genscript_get_item(struct genscript *, int);
+struct genscript_item *genscript_get_item(struct genscript *, u_int);
 
 /* for debug */
 void genscript_dump(struct genscript *);

--- a/gen/item.c
+++ b/gen/item.c
@@ -64,7 +64,7 @@ struct itemlist {
 
 	/* line editor */
 	int linebuffer_x, linebuffer_y;
-	int linebuffer_cursor;
+	u_int linebuffer_cursor;
 	char linebuf[128];
 	union item_value save;
 };
@@ -660,7 +660,7 @@ static int
 itemlist_editor(struct itemlist *itemlist, int c)
 {
 	struct item *item;
-	int i;
+	u_int i;
 
 	item = &itemlist->items[itemlist->focus];
 
@@ -734,7 +734,7 @@ itemlist_editor(struct itemlist *itemlist, int c)
 		break;
 	default:
 		i = strlen(itemlist->linebuf);
-		if ((i >= item->w) || (i >= sizeof(itemlist->linebuf))) {
+		if ((i >= (u_int)item->w) || (i >= sizeof(itemlist->linebuf))) {
 			BEEP();
 		} else {
 			i = strlen(&itemlist->linebuf[itemlist->linebuffer_cursor]) + 1;

--- a/gen/item.c
+++ b/gen/item.c
@@ -32,6 +32,7 @@
 #include <sys/ioctl.h>
 #include <curses.h>
 #include "item.h"
+#include "compat.h"
 
 #undef ITEM_DEBUG
 
@@ -42,12 +43,14 @@
 #define	REFRESH()	(void)0
 #define	PRINTF(format, args...)	printf(format, ## args)
 #define	BEEP()		(void)0
+#define	__debugused
 #else
 #define	CLEAR()		clear()
 #define	LOCATE(x, y)	move(y, x)
 #define	REFRESH()	refresh()
 #define	PRINTF(format, args...)	printw(format, ## args)
 #define	BEEP()		beep()
+#define	__debugused	__unused
 #endif
 
 #define	REVERSE()	standout()
@@ -147,7 +150,7 @@ itemlist_new(const char *template, struct item *items, int nitems)
 }
 
 static void
-item_dump(struct item *item)
+item_dump(struct item *item __debugused)
 {
 #ifdef ITEM_DEBUG
 	printf("<item=%p x=%d y=%d w=%d>\n",

--- a/gen/webserv.c
+++ b/gen/webserv.c
@@ -34,6 +34,7 @@
 #include <event.h>
 #include "webserv.h"
 #include "gen.h"
+#include "compat.h"
 
 static int webserv_output(struct webserv *, char *, int);
 static int webserv_reply_errcode(struct webserv *, int, const char *);
@@ -85,7 +86,7 @@ TAILQ_HEAD(, webserv) webserv_broadcastlist;
 unsigned int webserv_nclient;
 
 static int
-handler_index(struct webserv *web, const char *path, int argc, char *argv[])
+handler_index(struct webserv *web, const char *path __unused, int argc, char *argv[])
 {
 	char buf[1024 * 32];
 	FILE *fh;
@@ -132,7 +133,7 @@ handler_index(struct webserv *web, const char *path, int argc, char *argv[])
 }
 
 static int
-handler_stat(struct webserv *web, const char *path, int argc, char *argv[])
+handler_stat(struct webserv *web, const char *path __unused, int argc, char *argv[])
 {
 	char buf[1024];
 
@@ -153,7 +154,7 @@ handler_stat(struct webserv *web, const char *path, int argc, char *argv[])
 }
 
 static int
-handler_clear(struct webserv *web, const char *path, int argc, char *argv[])
+handler_clear(struct webserv *web, const char *path __unused, int argc __unused, char *argv[] __unused)
 {
 	statistics_clear();
 
@@ -164,7 +165,7 @@ handler_clear(struct webserv *web, const char *path, int argc, char *argv[])
 }
 
 static int
-handler_interface(struct webserv *web, const char *path, int argc, char *argv[])
+handler_interface(struct webserv *web, const char *path __unused, int argc, char *argv[])
 {
 	int ifno;
 	unsigned int n;

--- a/gen/webserv.c
+++ b/gen/webserv.c
@@ -294,7 +294,7 @@ webserv_getclientnum(void)
 }
 
 static void
-evt_readable_client_callback(evutil_socket_t fd, short event, void *arg)
+evt_readable_client_callback(evutil_socket_t fd __unused, short event __unused, void *arg)
 {
 	struct webserv *web;
 

--- a/gen/webserv.c
+++ b/gen/webserv.c
@@ -219,7 +219,7 @@ pathhandler(struct webserv *web, char *path)
 	struct urlhandler *match;
 	const char *p;
 	char *q;
-	int i;
+	u_int i;
 #define MAXARGV	32
 	char *argv[MAXARGV];
 


### PR DESCRIPTION
Tested on both FreeBSD and Ubuntu

Some notes:
a) commit a8fe468633d050f3835c8996bcfdddedbeca2313 might not be required.
It hides warning.

b) On Ubuntu, following two warnings are left:
gen.c:4646:7: warning: variable 'error' set but not used [-Wunused-but-set-variable]
                int error, i;
                    ^
gen.c:4676:7: warning: variable 'error' set but not used [-Wunused-but-set-variable]
                int error, i;
                    ^

