### PR TITLE
Improve web readability

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -54,9 +54,9 @@ PPS
 <br>
 <div id="pps_g" style="width:800px; height:250px;"></div>
 <br>
-<div id="drop_g" style="width:800px; height:100px;"></div>
+<div id="drop_g" style="width:800px; height:250px;"></div>
 <br>
-<div id="bps_g" style="width:800px; height:200px;"></div>
+<div id="bps_g" style="width:800px; height:250px;"></div>
 <br>
 <div id="pktsize_g" style="width:800px; height:125px;"></div>
 <br>

--- a/htdocs/pktgen.js
+++ b/htdocs/pktgen.js
@@ -239,7 +239,6 @@ function StartConnect(event, url)
 //			animateZoomes: true,
 //			showRangeSelector: true,
 			fillGraph: true,
-			valueRange: [64,1600],
 			rangeSelectorHeight: 30,
 			rangeSelectorPlotStrokeColor: 'yellow',
 			rangeSelectorPlotFilllColor: 'lightyellow'

--- a/htdocs/pktgen.js
+++ b/htdocs/pktgen.js
@@ -103,7 +103,7 @@ function LoopConnection(pps_g, pps_data, drop_g, drop_data, bps_g, bps_data, pkt
 
 			for (var i = 0; i < 2; i++) {
 				log('log',
-				    sprintf("%s pktsize:%d TXbps:%d RXbps:%d TXpps:%d RXpps:%d\n",
+				    sprintf("%s pktsize:%4d TXbps:%12d RXbps:%12d TXpps:%10d RXpps:%10d\n",
 				        json.statistics[i].interface,
 				        json.statistics[i].packetsize,
 				        json.statistics[i].TXbps, json.statistics[i].RXbps,

--- a/htdocs/pktgen.js
+++ b/htdocs/pktgen.js
@@ -207,6 +207,7 @@ function StartConnect(event, url)
 			drawPoints: true,
 			labels: ['Time', 'RX1', 'RX2'],
 			ylabel: 'drops',
+			logscale: true,
 //			animateZoomes: true,
 //			showRangeSelector: true,
 			fillGraph: true,


### PR DESCRIPTION
Four webUI changes:
- Improve readability of log area. It was hard to understand because items were not indented.
- Show pps, drops and mbps graphs with the same height.
- The drop count fluctuates from 0 to millions, so show it in log scale instead of linear scale.
- Make packetsize graph auto-scale to know transition easily.
![ipgen-graph-old](https://github.com/iij/ipgen/assets/6140236/f5260f4a-fe00-4120-904f-f9f78fef8252)
![ipgen-graph-new](https://github.com/iij/ipgen/assets/6140236/43e9088a-16c5-49fc-b148-c1d68333aead)
