### PR TITLE
RFC2544: Fix miscalculation of linkspeed

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -240,13 +240,11 @@ calc_mbps(unsigned int pktsize, unsigned long pps)
 	return _CALC_MBPS(pktsize, pps, opt_bps_include_preamble ? CALC_L1 : CALC_L2);
 }
 
-#if 0 /* Not used yet */
 static inline double
 calc_mbps_l1(unsigned int pktsize, unsigned long pps)
 {
 	return _CALC_MBPS(pktsize, pps, CALC_L1);
 }
-#endif
 
 /* sizeof(struct seqdata) = 6 bytes */
 struct seqdata {
@@ -2694,7 +2692,7 @@ rfc2544_showresult(void)
 	tmp = 0 ;
 	for (i = 0; i < rfc2544_ntest; i++) {
 		struct rfc2544_work *work = &rfc2544_work[i];
-		mbps = calc_mbps(work->pktsize, work->curpps);
+		mbps = calc_mbps_l1(work->pktsize, work->curpps);
 		if (tmp < mbps)
 			tmp = mbps;
 	}

--- a/gen/gen.c
+++ b/gen/gen.c
@@ -211,29 +211,42 @@ const uint8_t eth_zero[6] = { 0, 0, 0, 0, 0, 0 };
 
 char bps_desc[32];
 
+#define CALC_L1 1
+#define CALC_L2 0
+
 #define	PKTSIZE2FRAMESIZE(x, gap)	(DEFAULT_PREAMBLE + (x) + FCS + (gap))
-#define	_CALC_BPS(pktsize, pps)	\
-	((PKTSIZE2FRAMESIZE((pktsize) + ETHHDRSIZE, DEFAULT_IFG) * (pps)) * 8.0)
-#define	_CALC_MBPS(pktsize, pps)	\
-	(_CALC_BPS(pktsize, pps) / 1000.0 / 1000.0)
+#define	_CALC_BPS(pktsize, pps, l1l2)											\
+	(((pktsize) + ETHHDRSIZE + FCS + (((l1l2) == CALC_L1) ? DEFAULT_PREAMBLE + DEFAULT_IFG : 0)) * (pps) * 8.0)
+#define	_CALC_MBPS(pktsize, pps, l1l2)			\
+	(_CALC_BPS(pktsize, pps, l1l2) / 1000.0 / 1000.0)
 
 static inline double
 calc_bps(unsigned int pktsize, unsigned long pps)
 {
-	if (opt_bps_include_preamble)
-		return _CALC_BPS(pktsize, pps);
-
-	/* don't include ifg/preamble/fcs */
-	return (pktsize + ETHHDRSIZE + FCS) * pps * 8.0;
+	return _CALC_BPS(pktsize, pps, opt_bps_include_preamble ? CALC_L1 : CALC_L2);
 }
+
+#if 0 /* Not used yet */
+static inline double
+calc_bps_l1(unsigned int pktsize, unsigned long pps)
+{
+	return _CALC_BPS(pktsize, pps, CALC_L1);
+}
+#endif
 
 static inline double
 calc_mbps(unsigned int pktsize, unsigned long pps)
 {
-	if (opt_bps_include_preamble)
-		return _CALC_MBPS(pktsize, pps);
-	return calc_bps(pktsize, pps) / 1000.0 / 1000.0;
+	return _CALC_MBPS(pktsize, pps, opt_bps_include_preamble ? CALC_L1 : CALC_L2);
 }
+
+#if 0 /* Not used yet */
+static inline double
+calc_mbps_l1(unsigned int pktsize, unsigned long pps)
+{
+	return _CALC_MBPS(pktsize, pps, CALC_L1);
+}
+#endif
 
 /* sizeof(struct seqdata) = 6 bytes */
 struct seqdata {


### PR DESCRIPTION
 rfc2544_showresult() estimates the linkspeed from rfc2544_work[].
The calculated result may be wrong because it's calculate L2 speed
instead of L1.

Example:
framesize|0M  100M 200M 300M 400M 500M 600M 700M 800M 900M 1Gbps
---------+----+----+----+----+----+----+----+----+----+----+
      64 |##########################################          833.33Mbps, 1627605/14880952pps,  10.94%
     128 |                                                      0.00Mbps,       0/      0pps,    nan%
     512 |                                                      0.00Mbps,       0/      0pps,    nan%
    1024 |                                                      0.00Mbps,       0/      0pps,    nan%
    1280 |                                                      0.00Mbps,       0/      0pps,    nan%
    1408 |                                                      0.00Mbps,       0/      0pps,    nan%
    1518 |                                                      0.00Mbps,       0/      0pps,    nan%

framesize|0   |100k|200k|300k|400k|500k|600k|700k|800k|900k|1.0m|1.1m|1.2m|1.3m|1.4m|1.5m pps
---------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
      64 |#################################################################################1627605/14880952pps,  10.94%
     128 |                                                                                 0/      0pps,    nan%
     512 |                                                                                 0/      0pps,    nan%
    1024 |                                                                                 0/      0pps,    nan%
    1280 |                                                                                 0/      0pps,    nan%
    1408 |                                                                                 0/      0pps,    nan%
    1518 |                                                                                 0/      0pps,    nan%

1627604 pps is higher than 1Gbps.
Provide new calc_mbps_l1() and use it to force bps calculation L1 based.

NEW:
framesize|0G  1G   2G   3G   4G   5G   6G   7G   8G   9G   10Gbps
---------+----+----+----+----+----+----+----+----+----+----+
      64 |#####                                                952.38Mbps,  1860119/14880952pps,  12.50%
     128 |                                                       0.00Mbps,        0/       0pps,    nan%
     512 |                                                       0.00Mbps,        0/       0pps,    nan%
    1024 |                                                       0.00Mbps,        0/       0pps,    nan%
    1280 |                                                       0.00Mbps,        0/       0pps,    nan%
    1408 |                                                       0.00Mbps,        0/       0pps,    nan%
    1518 |                                                       0.00Mbps,        0/       0pps,    nan%

framesize|0   |1m  |2m  |3m  |4m  |5m  |6m  |7m  |8m  |9m  |10m |11m |12m |13m |14m |15m pps
---------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
      64 |#########                                                                   1860119/14880952pps,  12.50%
     128 |                                                                                  0/       0pps,    nan%
     512 |                                                                                  0/       0pps,    nan%
    1024 |                                                                                  0/       0pps,    nan%
    1280 |                                                                                  0/       0pps,    nan%
    1408 |                                                                                  0/       0pps,    nan%
    1518 |                                                                                  0/       0pps,    nan%