### PR TITLE
Fix utility functions for Linux

### DIFF
--- a/gen/util.c
+++ b/gen/util.c
@@ -229,11 +229,10 @@ interface_is_active(const char *ifname)
 	char buf[256];
 #ifdef __linux__
 	active = 0;
-	snprintf(buf, sizeof(buf), "ip link show up dev %s", ifname);
+	snprintf(buf, sizeof(buf), "ip link show %s", ifname);
 	fp = popen(buf, "r");
 	fgets(buf, sizeof(buf), fp);
-	/* If the interface is down, it returns empty string */
-	if (strnlen(buf, sizeof(buf) - 1) != 0)
+	if (strstr(buf, "state UP") != NULL)
 		active = 1;
 	pclose(fp);
 #else

--- a/gen/util.c
+++ b/gen/util.c
@@ -436,7 +436,7 @@ interface_get_baudrate(const char *ifname)
 	rc = ioctl(s, SIOCETHTOOL, &ifr);
 	if (rc != 0) {
 		close(s);
-		warn("ioctl(ETHTOOL_GLINK) failed\n");
+		warn("ioctl(ETHTOOL_GLINK) failed");
 		return 0;
 	}
 	ec.cmd = ETHTOOL_GSET;
@@ -444,12 +444,12 @@ interface_get_baudrate(const char *ifname)
 	rc = ioctl(s, SIOCETHTOOL, &ifr);
 	close(s);
 	if (rc != 0) {
-		warn("ioctl(ETHTOOL_GSET) failed\n");
+		warn("ioctl(ETHTOOL_GSET) failed");
 		return 0;
 	}
 	uint32_t speed = ethtool_cmd_speed(&ec);
-	if (speed == 0) {
-		warn("linkspeed unknown\n");
+	if (speed == 0 || speed == (uint16_t)(-1) || speed == (uint32_t)(-1)) {
+		warnx("linkspeed unknown");
 		return 0;
 	}
 	return IF_Mbps((uint64_t)speed);


### PR DESCRIPTION
`interface_get_baudrate` and `interface_is_active` didn't work correctly on Linux, so fix them.