### PR TITLE
Enable to build on Fedora without tweaks

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,9 +1,10 @@
 
 SUBDIRS := libpkt libaddrlist gen script htdocs
+MKDEP := $(CURDIR)/mkdep
 
 .PHONY: all $(SUBDIRS)
 
 all clean cleandir depend install: $(SUBDIRS)
 
 $(SUBDIRS):
-	$(MAKE) -C $@ $(MAKECMDGOALS)
+	$(MAKE) -C $@ $(MAKECMDGOALS) MKDEP=$(MKDEP)

--- a/gen/GNUmakefile
+++ b/gen/GNUmakefile
@@ -12,6 +12,11 @@ LDADD=		-L../libpkt -lpkt -L../libaddrlist -L/usr/local/lib -laddrlist -lpthread
 ifeq ($(shell uname),Linux)
 LDADD+=		-lbsd -lcrypto -lbpf
 CFLAGS+=	-DIPG_HACK -DUSE_AF_XDP
+HAS_XDP_XSK_H:=	$(wildcard /usr/include/xdp/xsk.h)
+ifdef HAS_XDP_XSK_H
+CFLAGS+=	-DHAS_XDP_XSK_H
+LDADD+=		-lxdp
+endif
 SRCS+=		arpresolv_linux.c af_xdp.c
 else
 CFLAGS+=	-DIPG_HACK -DUSE_NETMAP

--- a/gen/GNUmakefile
+++ b/gen/GNUmakefile
@@ -31,7 +31,7 @@ pktgen_item.c: pktgen.layout
 	perl layout_generator pktgen.layout
 
 depend: pktgen_item.c $(SRCS)
-	mkdep $(CFLAGS) $(SRCS)
+	$(MKDEP) $(CFLAGS) $(SRCS)
 
 clean: clean_test
 	rm -f pktgen_item.[ch]

--- a/gen/af_xdp.c
+++ b/gen/af_xdp.c
@@ -33,7 +33,11 @@
 #include <sys/resource.h>
 #include <linux/if_link.h>
 #include <bpf/bpf.h>
+#ifdef HAS_XDP_XSK_H
+#include <xdp/xsk.h>
+#else
 #include <bpf/xsk.h>
+#endif
 #include <bsd/sys/param.h>
 
 #include "af_xdp.h"

--- a/libaddrlist/GNUmakefile
+++ b/libaddrlist/GNUmakefile
@@ -22,7 +22,7 @@ test: libaddrlist.a
 	cc test.c libaddrlist.a && ./a.out
 
 depend:
-	mkdep $(SRCS)
+	$(MKDEP) $(SRCS)
 
 clean:
 	rm -f $(TARGETLIB) $(OBJS)

--- a/libpkt/GNUmakefile
+++ b/libpkt/GNUmakefile
@@ -31,7 +31,7 @@ $(TARGETLIB): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $^
 
 depend:
-	mkdep $(SRCS)
+	$(MKDEP) $(SRCS)
 
 clean:
 	rm -f $(TARGETLIB) $(OBJS)

--- a/mkdep
+++ b/mkdep
@@ -1,0 +1,113 @@
+#!/bin/sh -
+#
+#	$OpenBSD: mkdep.gcc.sh,v 1.8 1998/09/02 06:40:07 deraadt Exp $
+#	$NetBSD: mkdep.gcc.sh,v 1.9 1994/12/23 07:34:59 jtc Exp $
+#
+# Copyright (c) 1991, 1993
+#	The Regents of the University of California.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. All advertising materials mentioning features or use of this software
+#    must display the following acknowledgement:
+#	This product includes software developed by the University of
+#	California, Berkeley and its contributors.
+# 4. Neither the name of the University nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+#	@(#)mkdep.gcc.sh	8.1 (Berkeley) 6/6/93
+#
+
+D=.depend			# default dependency file is .depend
+append=0
+pflag=
+
+while :
+	do case "$1" in
+		# -a appends to the depend file
+		-a)
+			append=1
+			shift ;;
+
+		# -f allows you to select a makefile name
+		-f)
+			D=$2
+			shift; shift ;;
+
+		# the -p flag produces "program: program.c" style dependencies
+		# so .o's don't get produced
+		-p)
+			pflag=p
+			shift ;;
+		*)
+			break ;;
+	esac
+done
+
+if [ $# = 0 ] ; then
+	echo 'usage: mkdep [-p] [-f depend_file] [cc_flags] file ...'
+	exit 1
+fi
+
+DTMP=/tmp/mkdep$$
+TMP=$DTMP/mkdep
+
+um=`umask`
+umask 022
+if ! mkdir $DTMP ; then
+	echo failed to create tmp dir $DTMP
+	exit 1
+fi
+
+umask $um
+trap 'rm -rf $DTMP ; trap 2 ; kill -2 $$' 1 2 3 13 15
+
+if [ x$pflag = x ]; then
+	${CC:-cc} -M "$@" | sed -e 's; \./; ;g' > $TMP
+else
+	${CC:-cc} -M "$@" | sed -e 's;\.o :; :;' -e 's; \./; ;g' > $TMP
+fi
+
+if [ $? != 0 ]; then
+	echo 'mkdep: compile failed.'
+	rm -rf $DTMP
+	exit 1
+fi
+
+if [ $append = 1 ]; then
+	cat $TMP >> $D
+	if [ $? != 0 ]; then
+		echo 'mkdep: append failed.'
+		rm -rf $DTMP
+		exit 1
+	fi
+else
+	mv $TMP $D
+	if [ $? != 0 ]; then
+		echo 'mkdep: rename failed.'
+		rm -rf $DTMP
+		exit 1
+	fi
+fi
+
+rm -rf $DTMP
+exit 0


### PR DESCRIPTION
We needed some tweaks to build ipgen on Fedora Linux. This pull request enables to build without such tweaks.

Building ipgen requires mkdep script, but unfortunately no official packages of Fedora include it (bmake should). So we include it in the repository.

Tested on Fedora 39 and Ubuntu 22.04.