### PR TITLE
Linux: getdrvname: NUL-terminate readlink(2) result

### DIFF
--- a/gen/gen.c
+++ b/gen/gen.c
@@ -710,6 +710,9 @@ getdrvname(const char *ifname, char *drvname)
 	if (n == -1)
 		return -1;
 
+	/* NUL terminate */
+	linkbuf[n] = '\0';
+
 	/* ex /sys/bus/pci/drivers/ixgbe */
 	drvstr = strrchr(linkbuf, '/');
 	if (drvstr == NULL)


### PR DESCRIPTION
It is not guaranteed that [readlink(2)](https://pubs.opengroup.org/onlinepubs/9799919799/functions/readlink.html) NUL-terminate its result. Actually, neither BSD nor Linux implementations do so.

However, unfortunately, `getdrvname()` uses its result without properly NUL-termination. This can result in memory
corruption for members of `struct interface` that lie behind `drvname`:

https://github.com/iij/ipgen/blob/master/gen/gen.c#L928 (\*)

`getdrvname()` is used only for Linux, and readlink(2) is not called from elsewhere. Therefore, FreeBSD versions are
not affected.

Found by broken error message for `--ipg` option, when kernel patch is missing.

(\*) It is nice if we can use `strlcpy(3)` here, but that function was added to [glibc 2.38](https://lists.gnu.org/archive/html/info-gnu/2023-07/msg00010.html) in 2023...