### PR TITLE
Don't use CLLADDR() on FreeBSD.

### DIFF
--- a/gen/util.c
+++ b/gen/util.c
@@ -351,7 +351,8 @@ getiflinkaddr(const char *ifname, struct ether_addr *addr)
 			if ((sdl->sdl_type == IFT_ETHER) &&
 			    (sdl->sdl_alen == ETHER_ADDR_LEN)) {
 
-				memcpy(addr, (const struct ether_addr *)CLLADDR(sdl), ETHER_ADDR_LEN);
+				memcpy(addr, sdl->sdl_data + sdl->sdl_nlen,
+				    ETHER_ADDR_LEN);
 				found = 1;
 				break;
 			}


### PR DESCRIPTION
This macro was removed in FreeBSD 15.  There is no reason to use it in this code on any version of FreeBSD.  The constness is provided by the const struct sockaddr_dl * pointer.  The base type of char of sdl_data gives us all needed address arithmetics, no need to use the relic c_caddr_t.